### PR TITLE
Add support for attention masks and dropout

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,11 +2,11 @@ cff-version: 1.2.0
 message: "If you want to cite the kernel, feel free to use this (but only if you loved it 😊)"
 title: "JVP Flash Attention"
 abstract: "A Flash Attention Triton kernel with support for second-order derivatives, such as Jacobian-Vector Products (JVPs) and Hessian-Vector Products (HVPs)."
-date-released: 2025-09-03
+date-released: 2025-09-05
 authors:
   - family-names: "Morehead"
     given-names: "Alex"
-version: 0.0.1
+version: 0.0.2
 doi: 10.5281/zenodo.17050188
 license: "MIT"
 url: "https://zenodo.org/records/17050188"

--- a/README.md
+++ b/README.md
@@ -80,89 +80,89 @@ BENCHMARK SUMMARY
 ==============================================================================================================
 Seq Len    Causal   Mask       Method     Time (ms)    Mem (MB)     TFLOP/s      Max Error    Grad Check
 --------------------------------------------------------------------------------------------------------------
-32         False    additive   sdpa       0.788        0.64           0.0 TFLOP/s baseline     N/A
-32         False    additive   jvp_attn   0.496        0.23           0.0 TFLOP/s 1.95e-03     ✓
+32         False    additive   sdpa       0.785        0.64           0.0 TFLOP/s baseline     N/A
+32         False    additive   jvp_attn   0.475        0.23           0.0 TFLOP/s 1.95e-03     ✓
 
-32         False    boolean    sdpa       0.809        0.65           0.0 TFLOP/s baseline     N/A
-32         False    boolean    jvp_attn   0.488        0.22           0.0 TFLOP/s 1.95e-03     ✓
+32         False    boolean    sdpa       0.834        0.65           0.0 TFLOP/s baseline     N/A
+32         False    boolean    jvp_attn   0.469        0.22           0.0 TFLOP/s 1.95e-03     ✓
 
-32         False    none       sdpa       0.511        0.64           0.0 TFLOP/s baseline     N/A
-32         False    none       jvp_attn   0.493        0.22           0.0 TFLOP/s 1.95e-03     ✓
+32         False    none       sdpa       0.546        0.64           0.0 TFLOP/s baseline     N/A
+32         False    none       jvp_attn   0.465        0.22           0.0 TFLOP/s 1.95e-03     ✓
 
-32         True     none       sdpa       0.858        0.65           0.0 TFLOP/s baseline     N/A
-32         True     none       jvp_attn   0.501        0.22           0.0 TFLOP/s 1.95e-03     ✓
+32         True     none       sdpa       0.838        0.65           0.0 TFLOP/s baseline     N/A
+32         True     none       jvp_attn   0.464        0.22           0.0 TFLOP/s 1.95e-03     ✓
 
-64         False    additive   sdpa       0.809        1.41           0.0 TFLOP/s baseline     N/A
-64         False    additive   jvp_attn   0.502        0.47           0.0 TFLOP/s 9.77e-04     ✓
+64         False    additive   sdpa       0.790        1.41           0.0 TFLOP/s baseline     N/A
+64         False    additive   jvp_attn   0.487        0.47           0.0 TFLOP/s 9.77e-04     ✓
 
-64         False    boolean    sdpa       0.806        1.45           0.0 TFLOP/s baseline     N/A
-64         False    boolean    jvp_attn   0.488        0.43           0.0 TFLOP/s 9.77e-04     ✓
+64         False    boolean    sdpa       0.820        1.45           0.0 TFLOP/s baseline     N/A
+64         False    boolean    jvp_attn   0.473        0.43           0.0 TFLOP/s 9.77e-04     ✓
 
-64         False    none       sdpa       0.539        1.41           0.0 TFLOP/s baseline     N/A
-64         False    none       jvp_attn   0.494        0.43           0.0 TFLOP/s 9.77e-04     ✓
+64         False    none       sdpa       0.685        1.41           0.0 TFLOP/s baseline     N/A
+64         False    none       jvp_attn   0.474        0.43           0.0 TFLOP/s 9.77e-04     ✓
 
-64         True     none       sdpa       0.849        1.42           0.0 TFLOP/s baseline     N/A
-64         True     none       jvp_attn   0.479        0.43           0.0 TFLOP/s 1.95e-03     ✓
+64         True     none       sdpa       0.854        1.42           0.0 TFLOP/s baseline     N/A
+64         True     none       jvp_attn   0.499        0.43           0.0 TFLOP/s 1.95e-03     ✓
 
-128        False    additive   sdpa       0.803        3.28           0.0 TFLOP/s baseline     N/A
-128        False    additive   jvp_attn   0.488        1.02           0.1 TFLOP/s 9.77e-04     ✓
+128        False    additive   sdpa       0.769        3.28           0.0 TFLOP/s baseline     N/A
+128        False    additive   jvp_attn   0.494        1.02           0.1 TFLOP/s 9.77e-04     ✓
 
-128        False    boolean    sdpa       0.826        3.44           0.0 TFLOP/s baseline     N/A
-128        False    boolean    jvp_attn   0.472        0.86           0.1 TFLOP/s 9.77e-04     ✓
+128        False    boolean    sdpa       0.831        3.44           0.0 TFLOP/s baseline     N/A
+128        False    boolean    jvp_attn   0.468        0.86           0.1 TFLOP/s 9.77e-04     ✓
 
-128        False    none       sdpa       0.534        3.28           0.0 TFLOP/s baseline     N/A
-128        False    none       jvp_attn   0.519        0.86           0.1 TFLOP/s 9.77e-04     ✓
+128        False    none       sdpa       0.533        3.28           0.0 TFLOP/s baseline     N/A
+128        False    none       jvp_attn   0.470        0.86           0.1 TFLOP/s 9.77e-04     ✓
 
-128        True     none       sdpa       0.869        3.35           0.0 TFLOP/s baseline     N/A
-128        True     none       jvp_attn   0.497        0.86           0.0 TFLOP/s 1.95e-03     ✓
+128        True     none       sdpa       0.984        3.35           0.0 TFLOP/s baseline     N/A
+128        True     none       jvp_attn   0.483        0.86           0.0 TFLOP/s 1.95e-03     ✓
 
-256        False    additive   sdpa       0.861        9.69           0.1 TFLOP/s baseline     N/A
-256        False    additive   jvp_attn   0.511        2.35           0.3 TFLOP/s 9.77e-04     ✓
+256        False    additive   sdpa       1.142        9.69           0.1 TFLOP/s baseline     N/A
+256        False    additive   jvp_attn   0.473        2.35           0.4 TFLOP/s 9.77e-04     ✓
 
-256        False    boolean    sdpa       0.856        10.32          0.1 TFLOP/s baseline     N/A
-256        False    boolean    jvp_attn   0.494        1.72           0.3 TFLOP/s 9.77e-04     ✓
+256        False    boolean    sdpa       0.886        10.32          0.1 TFLOP/s baseline     N/A
+256        False    boolean    jvp_attn   0.466        1.72           0.4 TFLOP/s 9.77e-04     ✓
 
-256        False    none       sdpa       0.589        9.69           0.1 TFLOP/s baseline     N/A
-256        False    none       jvp_attn   0.476        1.72           0.4 TFLOP/s 9.77e-04     ✓
+256        False    none       sdpa       0.715        9.69           0.1 TFLOP/s baseline     N/A
+256        False    none       jvp_attn   0.472        1.72           0.4 TFLOP/s 9.77e-04     ✓
 
-256        True     none       sdpa       0.885        9.94           0.0 TFLOP/s baseline     N/A
-256        True     none       jvp_attn   0.480        1.72           0.2 TFLOP/s 1.95e-03     ✓
+256        True     none       sdpa       0.976        9.94           0.0 TFLOP/s baseline     N/A
+256        True     none       jvp_attn   0.464        1.72           0.2 TFLOP/s 1.95e-03     ✓
 
-512        False    additive   sdpa       1.003        31.88          0.3 TFLOP/s baseline     N/A
-512        False    additive   jvp_attn   0.508        5.95           1.3 TFLOP/s 4.88e-04     ✓
+512        False    additive   sdpa       1.399        31.88          0.2 TFLOP/s baseline     N/A
+512        False    additive   jvp_attn   0.481        5.95           1.4 TFLOP/s 4.88e-04     ✓
 
-512        False    boolean    sdpa       1.122        34.38          0.3 TFLOP/s baseline     N/A
-512        False    boolean    jvp_attn   0.515        3.45           1.3 TFLOP/s 4.88e-04     ✓
+512        False    boolean    sdpa       1.222        34.38          0.3 TFLOP/s baseline     N/A
+512        False    boolean    jvp_attn   0.489        3.45           1.4 TFLOP/s 4.88e-04     ✓
 
-512        False    none       sdpa       0.750        31.88          0.5 TFLOP/s baseline     N/A
-512        False    none       jvp_attn   0.496        3.45           1.4 TFLOP/s 4.88e-04     ✓
+512        False    none       sdpa       1.106        31.88          0.3 TFLOP/s baseline     N/A
+512        False    none       jvp_attn   0.475        3.45           1.4 TFLOP/s 4.88e-04     ✓
 
-512        True     none       sdpa       1.185        32.88          0.1 TFLOP/s baseline     N/A
-512        True     none       jvp_attn   0.496        3.45           0.7 TFLOP/s 1.95e-03     ✓
+512        True     none       sdpa       1.354        32.88          0.1 TFLOP/s baseline     N/A
+512        True     none       jvp_attn   0.493        3.45           0.7 TFLOP/s 1.95e-03     ✓
 
-1024       False    additive   sdpa       2.137        113.77         0.6 TFLOP/s baseline     N/A
-1024       False    additive   jvp_attn   0.503        16.89          5.4 TFLOP/s 4.88e-04     ✓
+1024       False    additive   sdpa       2.430        113.77         0.6 TFLOP/s baseline     N/A
+1024       False    additive   jvp_attn   0.480        16.89          5.7 TFLOP/s 4.88e-04     ✓
 
-1024       False    boolean    sdpa       2.166        123.77         0.6 TFLOP/s baseline     N/A
-1024       False    boolean    jvp_attn   0.516        6.89           5.3 TFLOP/s 4.88e-04     ✓
+1024       False    boolean    sdpa       2.889        123.77         0.5 TFLOP/s baseline     N/A
+1024       False    boolean    jvp_attn   0.483        6.89           5.7 TFLOP/s 4.88e-04     ✓
 
-1024       False    none       sdpa       1.934        113.77         0.7 TFLOP/s baseline     N/A
-1024       False    none       jvp_attn   0.520        6.89           5.3 TFLOP/s 4.88e-04     ✓
+1024       False    none       sdpa       2.457        113.77         0.6 TFLOP/s baseline     N/A
+1024       False    none       jvp_attn   0.467        6.89           5.9 TFLOP/s 4.88e-04     ✓
 
-1024       True     none       sdpa       2.169        117.77         0.3 TFLOP/s baseline     N/A
-1024       True     none       jvp_attn   0.493        6.89           2.8 TFLOP/s 1.95e-03     ✓
+1024       True     none       sdpa       2.670        117.77         0.3 TFLOP/s baseline     N/A
+1024       True     none       jvp_attn   0.500        6.89           2.7 TFLOP/s 1.95e-03     ✓
 
-2048       False    additive   sdpa       6.884        427.54         0.8 TFLOP/s baseline     N/A
-2048       False    additive   jvp_attn   0.702        53.79         15.6 TFLOP/s 2.44e-04     ✓
+2048       False    additive   sdpa       7.791        427.54         0.7 TFLOP/s baseline     N/A
+2048       False    additive   jvp_attn   0.696        53.79         15.7 TFLOP/s 2.44e-04     ✓
 
-2048       False    boolean    sdpa       6.992        467.54         0.8 TFLOP/s baseline     N/A
-2048       False    boolean    jvp_attn   0.566        13.79         19.3 TFLOP/s 2.44e-04     ✓
+2048       False    boolean    sdpa       7.673        467.54         0.7 TFLOP/s baseline     N/A
+2048       False    boolean    jvp_attn   0.755        13.79         14.5 TFLOP/s 2.44e-04     ✓
 
-2048       False    none       sdpa       5.820        427.54         0.9 TFLOP/s baseline     N/A
-2048       False    none       jvp_attn   0.507        13.79         21.6 TFLOP/s 2.44e-04     ✓
+2048       False    none       sdpa       7.773        427.54         0.7 TFLOP/s baseline     N/A
+2048       False    none       jvp_attn   0.614        13.79         17.8 TFLOP/s 2.44e-04     ✓
 
-2048       True     none       sdpa       6.906        443.54         0.4 TFLOP/s baseline     N/A
-2048       True     none       jvp_attn   0.522        13.79         10.5 TFLOP/s 1.95e-03     ✓
+2048       True     none       sdpa       8.609        443.54         0.3 TFLOP/s baseline     N/A
+2048       True     none       jvp_attn   0.464        13.79         11.8 TFLOP/s 1.95e-03     ✓
 
 
 ================================================================================
@@ -170,27 +170,27 @@ MASK TYPE PERFORMANCE COMPARISON
 ================================================================================
 Seq Len    Causal   Method     No Mask         Boolean Mask    Additive Mask
 --------------------------------------------------------------------------------
-32         False    jvp_attn   0.49 ms         0.49 ms (0.99x) 0.50 ms (1.01x)
-32         True     jvp_attn   0.50 ms         N/A             N/A
-64         False    jvp_attn   0.49 ms         0.49 ms (0.99x) 0.50 ms (1.02x)
-64         True     jvp_attn   0.48 ms         N/A             N/A
-128        False    jvp_attn   0.52 ms         0.47 ms (0.91x) 0.49 ms (0.94x)
-128        True     jvp_attn   0.50 ms         N/A             N/A
-256        False    jvp_attn   0.48 ms         0.49 ms (1.04x) 0.51 ms (1.07x)
-256        True     jvp_attn   0.48 ms         N/A             N/A
-512        False    jvp_attn   0.50 ms         0.52 ms (1.04x) 0.51 ms (1.02x)
-512        True     jvp_attn   0.50 ms         N/A             N/A
-1024       False    jvp_attn   0.52 ms         0.52 ms (0.99x) 0.50 ms (0.97x)
-1024       True     jvp_attn   0.49 ms         N/A             N/A
-2048       False    jvp_attn   0.51 ms         0.57 ms (1.12x) 0.70 ms (1.39x)
-2048       True     jvp_attn   0.52 ms         N/A             N/A
+32         False    jvp_attn   0.47 ms         0.47 ms (1.01x) 0.48 ms (1.02x)
+32         True     jvp_attn   0.46 ms         N/A             N/A
+64         False    jvp_attn   0.47 ms         0.47 ms (1.00x) 0.49 ms (1.03x)
+64         True     jvp_attn   0.50 ms         N/A             N/A
+128        False    jvp_attn   0.47 ms         0.47 ms (1.00x) 0.49 ms (1.05x)
+128        True     jvp_attn   0.48 ms         N/A             N/A
+256        False    jvp_attn   0.47 ms         0.47 ms (0.99x) 0.47 ms (1.00x)
+256        True     jvp_attn   0.46 ms         N/A             N/A
+512        False    jvp_attn   0.47 ms         0.49 ms (1.03x) 0.48 ms (1.01x)
+512        True     jvp_attn   0.49 ms         N/A             N/A
+1024       False    jvp_attn   0.47 ms         0.48 ms (1.03x) 0.48 ms (1.03x)
+1024       True     jvp_attn   0.50 ms         N/A             N/A
+2048       False    jvp_attn   0.61 ms         0.75 ms (1.23x) 0.70 ms (1.13x)
+2048       True     jvp_attn   0.46 ms         N/A             N/A
 
 ============================================================
 STATISTICS
 ============================================================
-Average speedup: 3.44x
-Min speedup: 1.03x
-Max speedup: 13.23x
+Average speedup: 4.00x
+Min speedup: 1.13x
+Max speedup: 18.54x
 
 Accuracy: 28/28 tests passed
 ✓ All accuracy checks passed!
@@ -204,89 +204,89 @@ BENCHMARK SUMMARY
 ==============================================================================================================
 Seq Len    Causal   Mask       Method     Time (ms)    Mem (MB)     TFLOP/s      Max Error    Grad Check
 --------------------------------------------------------------------------------------------------------------
-32         False    additive   sdpa       0.764        0.64           0.0 TFLOP/s baseline     N/A
-32         False    additive   jvp_attn   0.497        0.23           0.0 TFLOP/s 1.56e-02     ✓
+32         False    additive   sdpa       0.900        0.64           0.0 TFLOP/s baseline     N/A
+32         False    additive   jvp_attn   0.661        0.23           0.0 TFLOP/s 1.56e-02     ✓
 
-32         False    boolean    sdpa       0.786        0.65           0.0 TFLOP/s baseline     N/A
-32         False    boolean    jvp_attn   0.468        0.22           0.0 TFLOP/s 1.56e-02     ✓
+32         False    boolean    sdpa       0.883        0.65           0.0 TFLOP/s baseline     N/A
+32         False    boolean    jvp_attn   0.578        0.22           0.0 TFLOP/s 1.56e-02     ✓
 
-32         False    none       sdpa       0.494        0.64           0.0 TFLOP/s baseline     N/A
-32         False    none       jvp_attn   0.470        0.22           0.0 TFLOP/s 1.56e-02     ✓
+32         False    none       sdpa       0.603        0.64           0.0 TFLOP/s baseline     N/A
+32         False    none       jvp_attn   0.513        0.22           0.0 TFLOP/s 1.56e-02     ✓
 
-32         True     none       sdpa       0.850        0.65           0.0 TFLOP/s baseline     N/A
-32         True     none       jvp_attn   0.469        0.22           0.0 TFLOP/s 1.56e-02     ✓
+32         True     none       sdpa       0.915        0.65           0.0 TFLOP/s baseline     N/A
+32         True     none       jvp_attn   0.519        0.22           0.0 TFLOP/s 1.56e-02     ✓
 
-64         False    additive   sdpa       0.814        1.41           0.0 TFLOP/s baseline     N/A
-64         False    additive   jvp_attn   0.488        0.47           0.0 TFLOP/s 7.81e-03     ✓
+64         False    additive   sdpa       0.833        1.41           0.0 TFLOP/s baseline     N/A
+64         False    additive   jvp_attn   0.531        0.47           0.0 TFLOP/s 7.81e-03     ✓
 
-64         False    boolean    sdpa       0.916        1.45           0.0 TFLOP/s baseline     N/A
-64         False    boolean    jvp_attn   0.540        0.43           0.0 TFLOP/s 7.81e-03     ✓
+64         False    boolean    sdpa       0.870        1.45           0.0 TFLOP/s baseline     N/A
+64         False    boolean    jvp_attn   0.545        0.43           0.0 TFLOP/s 7.81e-03     ✓
 
-64         False    none       sdpa       0.515        1.41           0.0 TFLOP/s baseline     N/A
-64         False    none       jvp_attn   0.471        0.43           0.0 TFLOP/s 7.81e-03     ✓
+64         False    none       sdpa       0.565        1.41           0.0 TFLOP/s baseline     N/A
+64         False    none       jvp_attn   0.508        0.43           0.0 TFLOP/s 7.81e-03     ✓
 
-64         True     none       sdpa       0.821        1.42           0.0 TFLOP/s baseline     N/A
-64         True     none       jvp_attn   0.471        0.43           0.0 TFLOP/s 1.56e-02     ✓
+64         True     none       sdpa       0.939        1.42           0.0 TFLOP/s baseline     N/A
+64         True     none       jvp_attn   0.520        0.43           0.0 TFLOP/s 1.56e-02     ✓
 
-128        False    additive   sdpa       0.767        3.28           0.0 TFLOP/s baseline     N/A
-128        False    additive   jvp_attn   0.487        1.02           0.1 TFLOP/s 7.81e-03     ✓
+128        False    additive   sdpa       0.864        3.28           0.0 TFLOP/s baseline     N/A
+128        False    additive   jvp_attn   0.476        1.02           0.1 TFLOP/s 7.81e-03     ✓
 
-128        False    boolean    sdpa       0.821        3.44           0.0 TFLOP/s baseline     N/A
-128        False    boolean    jvp_attn   0.482        0.86           0.1 TFLOP/s 7.81e-03     ✓
+128        False    boolean    sdpa       0.839        3.44           0.0 TFLOP/s baseline     N/A
+128        False    boolean    jvp_attn   0.460        0.86           0.1 TFLOP/s 7.81e-03     ✓
 
-128        False    none       sdpa       0.506        3.28           0.0 TFLOP/s baseline     N/A
-128        False    none       jvp_attn   0.486        0.86           0.1 TFLOP/s 7.81e-03     ✓
+128        False    none       sdpa       0.798        3.28           0.0 TFLOP/s baseline     N/A
+128        False    none       jvp_attn   0.519        0.86           0.1 TFLOP/s 7.81e-03     ✓
 
-128        True     none       sdpa       0.843        3.35           0.0 TFLOP/s baseline     N/A
-128        True     none       jvp_attn   0.473        0.86           0.0 TFLOP/s 1.56e-02     ✓
+128        True     none       sdpa       0.886        3.35           0.0 TFLOP/s baseline     N/A
+128        True     none       jvp_attn   0.504        0.86           0.0 TFLOP/s 1.56e-02     ✓
 
-256        False    additive   sdpa       0.822        9.69           0.1 TFLOP/s baseline     N/A
-256        False    additive   jvp_attn   0.495        2.35           0.3 TFLOP/s 7.81e-03     ✓
+256        False    additive   sdpa       1.164        9.69           0.1 TFLOP/s baseline     N/A
+256        False    additive   jvp_attn   0.471        2.35           0.4 TFLOP/s 7.81e-03     ✓
 
-256        False    boolean    sdpa       0.849        10.32          0.1 TFLOP/s baseline     N/A
-256        False    boolean    jvp_attn   0.470        1.72           0.4 TFLOP/s 7.81e-03     ✓
+256        False    boolean    sdpa       0.918        10.32          0.1 TFLOP/s baseline     N/A
+256        False    boolean    jvp_attn   0.468        1.72           0.4 TFLOP/s 7.81e-03     ✓
 
-256        False    none       sdpa       0.602        9.69           0.1 TFLOP/s baseline     N/A
-256        False    none       jvp_attn   0.465        1.72           0.4 TFLOP/s 3.91e-03     ✓
+256        False    none       sdpa       0.780        9.69           0.1 TFLOP/s baseline     N/A
+256        False    none       jvp_attn   0.463        1.72           0.4 TFLOP/s 3.91e-03     ✓
 
-256        True     none       sdpa       1.028        9.94           0.0 TFLOP/s baseline     N/A
-256        True     none       jvp_attn   0.462        1.72           0.2 TFLOP/s 1.56e-02     ✓
+256        True     none       sdpa       1.187        9.94           0.0 TFLOP/s baseline     N/A
+256        True     none       jvp_attn   0.463        1.72           0.2 TFLOP/s 1.56e-02     ✓
 
-512        False    additive   sdpa       1.104        31.88          0.3 TFLOP/s baseline     N/A
-512        False    additive   jvp_attn   0.617        5.95           1.1 TFLOP/s 3.91e-03     ✓
+512        False    additive   sdpa       1.059        31.88          0.3 TFLOP/s baseline     N/A
+512        False    additive   jvp_attn   0.476        5.95           1.4 TFLOP/s 3.91e-03     ✓
 
-512        False    boolean    sdpa       1.158        34.38          0.3 TFLOP/s baseline     N/A
-512        False    boolean    jvp_attn   0.502        3.45           1.4 TFLOP/s 3.91e-03     ✓
+512        False    boolean    sdpa       1.053        34.38          0.3 TFLOP/s baseline     N/A
+512        False    boolean    jvp_attn   0.463        3.45           1.5 TFLOP/s 3.91e-03     ✓
 
-512        False    none       sdpa       0.924        31.88          0.4 TFLOP/s baseline     N/A
-512        False    none       jvp_attn   0.478        3.45           1.4 TFLOP/s 3.91e-03     ✓
+512        False    none       sdpa       1.131        31.88          0.3 TFLOP/s baseline     N/A
+512        False    none       jvp_attn   0.466        3.45           1.5 TFLOP/s 3.91e-03     ✓
 
-512        True     none       sdpa       0.935        32.88          0.2 TFLOP/s baseline     N/A
-512        True     none       jvp_attn   0.462        3.45           0.7 TFLOP/s 1.56e-02     ✓
+512        True     none       sdpa       1.651        32.88          0.1 TFLOP/s baseline     N/A
+512        True     none       jvp_attn   0.470        3.45           0.7 TFLOP/s 1.56e-02     ✓
 
-1024       False    additive   sdpa       2.151        113.77         0.6 TFLOP/s baseline     N/A
-1024       False    additive   jvp_attn   0.497        16.89          5.5 TFLOP/s 3.91e-03     ✓
+1024       False    additive   sdpa       2.525        113.77         0.5 TFLOP/s baseline     N/A
+1024       False    additive   jvp_attn   0.489        16.89          5.6 TFLOP/s 3.91e-03     ✓
 
-1024       False    boolean    sdpa       2.224        123.77         0.6 TFLOP/s baseline     N/A
-1024       False    boolean    jvp_attn   0.487        6.89           5.6 TFLOP/s 3.91e-03     ✓
+1024       False    boolean    sdpa       2.775        123.77         0.5 TFLOP/s baseline     N/A
+1024       False    boolean    jvp_attn   0.471        6.89           5.8 TFLOP/s 3.91e-03     ✓
 
-1024       False    none       sdpa       1.936        113.77         0.7 TFLOP/s baseline     N/A
-1024       False    none       jvp_attn   0.487        6.89           5.6 TFLOP/s 3.91e-03     ✓
+1024       False    none       sdpa       2.393        113.77         0.6 TFLOP/s baseline     N/A
+1024       False    none       jvp_attn   0.482        6.89           5.7 TFLOP/s 3.91e-03     ✓
 
-1024       True     none       sdpa       2.149        117.77         0.3 TFLOP/s baseline     N/A
-1024       True     none       jvp_attn   0.484        6.89           2.8 TFLOP/s 1.56e-02     ✓
+1024       True     none       sdpa       2.319        117.77         0.3 TFLOP/s baseline     N/A
+1024       True     none       jvp_attn   0.463        6.89           3.0 TFLOP/s 1.56e-02     ✓
 
-2048       False    additive   sdpa       6.891        427.54         0.8 TFLOP/s baseline     N/A
-2048       False    additive   jvp_attn   0.550        53.79         19.9 TFLOP/s 1.95e-03     ✓
+2048       False    additive   sdpa       8.504        427.54         0.6 TFLOP/s baseline     N/A
+2048       False    additive   jvp_attn   0.804        53.79         13.6 TFLOP/s 1.95e-03     ✓
 
-2048       False    boolean    sdpa       7.020        467.54         0.8 TFLOP/s baseline     N/A
-2048       False    boolean    jvp_attn   0.550        13.79         19.9 TFLOP/s 1.95e-03     ✓
+2048       False    boolean    sdpa       8.944        467.54         0.6 TFLOP/s baseline     N/A
+2048       False    boolean    jvp_attn   0.852        13.79         12.9 TFLOP/s 1.95e-03     ✓
 
-2048       False    none       sdpa       5.827        427.54         0.9 TFLOP/s baseline     N/A
-2048       False    none       jvp_attn   0.532        13.79         20.6 TFLOP/s 1.95e-03     ✓
+2048       False    none       sdpa       6.810        427.54         0.8 TFLOP/s baseline     N/A
+2048       False    none       jvp_attn   0.900        13.79         12.2 TFLOP/s 1.95e-03     ✓
 
-2048       True     none       sdpa       6.914        443.54         0.4 TFLOP/s baseline     N/A
-2048       True     none       jvp_attn   0.549        13.79         10.0 TFLOP/s 3.12e-02     ✓
+2048       True     none       sdpa       8.846        443.54         0.3 TFLOP/s baseline     N/A
+2048       True     none       jvp_attn   0.508        13.79         10.8 TFLOP/s 3.12e-02     ✓
 
 
 ================================================================================
@@ -294,27 +294,27 @@ MASK TYPE PERFORMANCE COMPARISON
 ================================================================================
 Seq Len    Causal   Method     No Mask         Boolean Mask    Additive Mask
 --------------------------------------------------------------------------------
-32         False    jvp_attn   0.47 ms         0.47 ms (1.00x) 0.50 ms (1.06x)
-32         True     jvp_attn   0.47 ms         N/A             N/A
-64         False    jvp_attn   0.47 ms         0.54 ms (1.15x) 0.49 ms (1.04x)
-64         True     jvp_attn   0.47 ms         N/A             N/A
-128        False    jvp_attn   0.49 ms         0.48 ms (0.99x) 0.49 ms (1.00x)
-128        True     jvp_attn   0.47 ms         N/A             N/A
-256        False    jvp_attn   0.47 ms         0.47 ms (1.01x) 0.49 ms (1.06x)
+32         False    jvp_attn   0.51 ms         0.58 ms (1.13x) 0.66 ms (1.29x)
+32         True     jvp_attn   0.52 ms         N/A             N/A
+64         False    jvp_attn   0.51 ms         0.54 ms (1.07x) 0.53 ms (1.05x)
+64         True     jvp_attn   0.52 ms         N/A             N/A
+128        False    jvp_attn   0.52 ms         0.46 ms (0.89x) 0.48 ms (0.92x)
+128        True     jvp_attn   0.50 ms         N/A             N/A
+256        False    jvp_attn   0.46 ms         0.47 ms (1.01x) 0.47 ms (1.02x)
 256        True     jvp_attn   0.46 ms         N/A             N/A
-512        False    jvp_attn   0.48 ms         0.50 ms (1.05x) 0.62 ms (1.29x)
-512        True     jvp_attn   0.46 ms         N/A             N/A
-1024       False    jvp_attn   0.49 ms         0.49 ms (1.00x) 0.50 ms (1.02x)
-1024       True     jvp_attn   0.48 ms         N/A             N/A
-2048       False    jvp_attn   0.53 ms         0.55 ms (1.04x) 0.55 ms (1.03x)
-2048       True     jvp_attn   0.55 ms         N/A             N/A
+512        False    jvp_attn   0.47 ms         0.46 ms (0.99x) 0.48 ms (1.02x)
+512        True     jvp_attn   0.47 ms         N/A             N/A
+1024       False    jvp_attn   0.48 ms         0.47 ms (0.98x) 0.49 ms (1.01x)
+1024       True     jvp_attn   0.46 ms         N/A             N/A
+2048       False    jvp_attn   0.90 ms         0.85 ms (0.95x) 0.80 ms (0.89x)
+2048       True     jvp_attn   0.51 ms         N/A             N/A
 
 ============================================================
 STATISTICS
 ============================================================
-Average speedup: 3.56x
-Min speedup: 1.04x
-Max speedup: 12.76x
+Average speedup: 3.75x
+Min speedup: 1.11x
+Max speedup: 17.40x
 
 Accuracy: 28/28 tests passed
 ✓ All accuracy checks passed!
@@ -329,88 +329,88 @@ BENCHMARK SUMMARY
 Seq Len    Causal   Mask       Method     Time (ms)    Mem (MB)     TFLOP/s      Max Error    Grad Check
 --------------------------------------------------------------------------------------------------------------
 32         False    additive   sdpa       0.724        0.51           0.0 TFLOP/s baseline     N/A
-32         False    additive   jvp_attn   0.495        0.45           0.0 TFLOP/s 7.21e-03     ✓
+32         False    additive   jvp_attn   0.523        0.45           0.0 TFLOP/s 7.21e-03     ✓
 
-32         False    boolean    sdpa       0.718        0.53           0.0 TFLOP/s baseline     N/A
-32         False    boolean    jvp_attn   0.487        0.43           0.0 TFLOP/s 7.21e-03     ✓
+32         False    boolean    sdpa       0.764        0.53           0.0 TFLOP/s baseline     N/A
+32         False    boolean    jvp_attn   0.500        0.43           0.0 TFLOP/s 7.21e-03     ✓
 
-32         False    none       sdpa       0.438        0.51           0.0 TFLOP/s baseline     N/A
-32         False    none       jvp_attn   0.484        0.43           0.0 TFLOP/s 7.22e-03     ✓
+32         False    none       sdpa       0.454        0.51           0.0 TFLOP/s baseline     N/A
+32         False    none       jvp_attn   0.521        0.43           0.0 TFLOP/s 7.22e-03     ✓
 
-32         True     none       sdpa       0.750        0.51           0.0 TFLOP/s baseline     N/A
-32         True     none       jvp_attn   0.475        0.43           0.0 TFLOP/s 6.18e-03     ✓
+32         True     none       sdpa       0.771        0.51           0.0 TFLOP/s baseline     N/A
+32         True     none       jvp_attn   0.530        0.43           0.0 TFLOP/s 6.18e-03     ✓
 
-64         False    additive   sdpa       0.697        1.09           0.0 TFLOP/s baseline     N/A
-64         False    additive   jvp_attn   0.475        0.94           0.0 TFLOP/s 7.17e-03     ✓
+64         False    additive   sdpa       0.731        1.09           0.0 TFLOP/s baseline     N/A
+64         False    additive   jvp_attn   0.503        0.94           0.0 TFLOP/s 7.17e-03     ✓
 
-64         False    boolean    sdpa       0.710        1.17           0.0 TFLOP/s baseline     N/A
-64         False    boolean    jvp_attn   0.474        0.86           0.0 TFLOP/s 7.17e-03     ✓
+64         False    boolean    sdpa       0.760        1.17           0.0 TFLOP/s baseline     N/A
+64         False    boolean    jvp_attn   0.501        0.86           0.0 TFLOP/s 7.17e-03     ✓
 
-64         False    none       sdpa       0.432        1.09           0.0 TFLOP/s baseline     N/A
-64         False    none       jvp_attn   0.478        0.86           0.0 TFLOP/s 7.03e-03     ✓
+64         False    none       sdpa       0.447        1.09           0.0 TFLOP/s baseline     N/A
+64         False    none       jvp_attn   0.497        0.86           0.0 TFLOP/s 7.03e-03     ✓
 
-64         True     none       sdpa       0.783        1.11           0.0 TFLOP/s baseline     N/A
-64         True     none       jvp_attn   0.471        0.86           0.0 TFLOP/s 6.18e-03     ✓
+64         True     none       sdpa       0.790        1.11           0.0 TFLOP/s baseline     N/A
+64         True     none       jvp_attn   0.507        0.86           0.0 TFLOP/s 6.18e-03     ✓
 
-128        False    additive   sdpa       0.755        2.81           0.0 TFLOP/s baseline     N/A
-128        False    additive   jvp_attn   0.523        2.03           0.1 TFLOP/s 5.41e-03     ✓
+128        False    additive   sdpa       0.702        2.81           0.0 TFLOP/s baseline     N/A
+128        False    additive   jvp_attn   0.494        2.03           0.1 TFLOP/s 5.41e-03     ✓
 
-128        False    boolean    sdpa       0.767        3.13           0.0 TFLOP/s baseline     N/A
-128        False    boolean    jvp_attn   0.508        1.72           0.1 TFLOP/s 5.41e-03     ✓
+128        False    boolean    sdpa       0.826        3.13           0.0 TFLOP/s baseline     N/A
+128        False    boolean    jvp_attn   0.478        1.72           0.1 TFLOP/s 5.41e-03     ✓
 
-128        False    none       sdpa       0.467        2.81           0.0 TFLOP/s baseline     N/A
-128        False    none       jvp_attn   0.497        1.72           0.1 TFLOP/s 5.07e-03     ✓
+128        False    none       sdpa       0.579        2.81           0.0 TFLOP/s baseline     N/A
+128        False    none       jvp_attn   0.514        1.72           0.1 TFLOP/s 5.07e-03     ✓
 
-128        True     none       sdpa       0.743        2.88           0.0 TFLOP/s baseline     N/A
-128        True     none       jvp_attn   0.467        1.72           0.0 TFLOP/s 6.18e-03     ✓
+128        True     none       sdpa       0.837        2.88           0.0 TFLOP/s baseline     N/A
+128        True     none       jvp_attn   0.537        1.72           0.0 TFLOP/s 6.18e-03     ✓
 
-256        False    additive   sdpa       0.745        8.75           0.1 TFLOP/s baseline     N/A
-256        False    additive   jvp_attn   0.495        4.69           0.3 TFLOP/s 3.41e-03     ✓
+256        False    additive   sdpa       0.687        8.75           0.1 TFLOP/s baseline     N/A
+256        False    additive   jvp_attn   0.481        4.69           0.4 TFLOP/s 3.41e-03     ✓
 
-256        False    boolean    sdpa       0.790        10.00          0.1 TFLOP/s baseline     N/A
-256        False    boolean    jvp_attn   0.522        3.44           0.3 TFLOP/s 3.41e-03     ✓
+256        False    boolean    sdpa       0.797        10.00          0.1 TFLOP/s baseline     N/A
+256        False    boolean    jvp_attn   0.506        3.44           0.3 TFLOP/s 3.41e-03     ✓
 
-256        False    none       sdpa       0.502        8.75           0.2 TFLOP/s baseline     N/A
-256        False    none       jvp_attn   0.487        3.44           0.4 TFLOP/s 3.67e-03     ✓
+256        False    none       sdpa       0.466        8.75           0.2 TFLOP/s baseline     N/A
+256        False    none       jvp_attn   0.474        3.44           0.4 TFLOP/s 3.67e-03     ✓
 
-256        True     none       sdpa       0.780        9.00           0.1 TFLOP/s baseline     N/A
-256        True     none       jvp_attn   0.487        3.44           0.2 TFLOP/s 5.78e-03     ✓
+256        True     none       sdpa       1.024        9.00           0.0 TFLOP/s baseline     N/A
+256        True     none       jvp_attn   0.496        3.44           0.2 TFLOP/s 5.78e-03     ✓
 
-512        False    additive   sdpa       1.013        30.01          0.3 TFLOP/s baseline     N/A
-512        False    additive   jvp_attn   0.503        11.88          1.4 TFLOP/s 3.09e-03     ✓
+512        False    additive   sdpa       0.982        30.01          0.3 TFLOP/s baseline     N/A
+512        False    additive   jvp_attn   0.515        11.88          1.3 TFLOP/s 3.09e-03     ✓
 
-512        False    boolean    sdpa       0.833        35.01          0.4 TFLOP/s baseline     N/A
-512        False    boolean    jvp_attn   0.485        6.88           1.4 TFLOP/s 3.09e-03     ✓
+512        False    boolean    sdpa       1.413        35.01          0.2 TFLOP/s baseline     N/A
+512        False    boolean    jvp_attn   0.487        6.88           1.4 TFLOP/s 3.09e-03     ✓
 
-512        False    none       sdpa       0.698        30.01          0.5 TFLOP/s baseline     N/A
-512        False    none       jvp_attn   0.489        6.88           1.4 TFLOP/s 2.88e-03     ✓
+512        False    none       sdpa       1.362        30.01          0.3 TFLOP/s baseline     N/A
+512        False    none       jvp_attn   0.481        6.88           1.4 TFLOP/s 2.88e-03     ✓
 
-512        True     none       sdpa       1.073        31.01          0.2 TFLOP/s baseline     N/A
-512        True     none       jvp_attn   0.496        6.88           0.7 TFLOP/s 5.13e-03     ✓
+512        True     none       sdpa       0.968        31.01          0.2 TFLOP/s baseline     N/A
+512        True     none       jvp_attn   0.481        6.88           0.7 TFLOP/s 5.13e-03     ✓
 
-1024       False    additive   sdpa       2.139        110.02         0.6 TFLOP/s baseline     N/A
-1024       False    additive   jvp_attn   0.526        33.77          5.2 TFLOP/s 2.84e-03     ✓
+1024       False    additive   sdpa       2.381        110.02         0.6 TFLOP/s baseline     N/A
+1024       False    additive   jvp_attn   0.708        33.77          3.9 TFLOP/s 2.84e-03     ✓
 
-1024       False    boolean    sdpa       2.092        130.02         0.7 TFLOP/s baseline     N/A
-1024       False    boolean    jvp_attn   0.529        13.77          5.2 TFLOP/s 2.84e-03     ✓
+1024       False    boolean    sdpa       3.475        130.02         0.4 TFLOP/s baseline     N/A
+1024       False    boolean    jvp_attn   0.593        13.77          4.6 TFLOP/s 2.84e-03     ✓
 
-1024       False    none       sdpa       1.845        110.02         0.7 TFLOP/s baseline     N/A
-1024       False    none       jvp_attn   0.503        13.77          5.4 TFLOP/s 2.61e-03     ✓
+1024       False    none       sdpa       2.246        110.02         0.6 TFLOP/s baseline     N/A
+1024       False    none       jvp_attn   0.488        13.77          5.6 TFLOP/s 2.61e-03     ✓
 
-1024       True     none       sdpa       2.107        115.02         0.3 TFLOP/s baseline     N/A
-1024       True     none       jvp_attn   0.523        13.77          2.6 TFLOP/s 5.61e-03     ✓
+1024       True     none       sdpa       2.700        115.02         0.3 TFLOP/s baseline     N/A
+1024       True     none       jvp_attn   0.531        13.77          2.6 TFLOP/s 5.61e-03     ✓
 
-2048       False    additive   sdpa       6.535        420.04         0.8 TFLOP/s baseline     N/A
-2048       False    additive   jvp_attn   0.893        107.54        12.3 TFLOP/s 1.57e-03     ✓
+2048       False    additive   sdpa       8.094        420.04         0.7 TFLOP/s baseline     N/A
+2048       False    additive   jvp_attn   1.274        107.54         8.6 TFLOP/s 1.57e-03     ✓
 
-2048       False    boolean    sdpa       6.656        500.04         0.8 TFLOP/s baseline     N/A
-2048       False    boolean    jvp_attn   1.167        27.54          9.4 TFLOP/s 1.57e-03     ✓
+2048       False    boolean    sdpa       7.980        500.04         0.7 TFLOP/s baseline     N/A
+2048       False    boolean    jvp_attn   1.332        27.54          8.2 TFLOP/s 1.57e-03     ✓
 
-2048       False    none       sdpa       4.616        420.04         1.2 TFLOP/s baseline     N/A
-2048       False    none       jvp_attn   0.759        27.54         14.4 TFLOP/s 1.56e-03     ✓
+2048       False    none       sdpa       6.471        420.04         0.8 TFLOP/s baseline     N/A
+2048       False    none       jvp_attn   1.345        27.54          8.1 TFLOP/s 1.56e-03     ✓
 
-2048       True     none       sdpa       6.348        436.04         0.4 TFLOP/s baseline     N/A
-2048       True     none       jvp_attn   0.553        27.54          9.9 TFLOP/s 6.47e-03     ✓
+2048       True     none       sdpa       8.308        436.04         0.3 TFLOP/s baseline     N/A
+2048       True     none       jvp_attn   0.749        27.54          7.3 TFLOP/s 6.47e-03     ✓
 
 
 ================================================================================
@@ -418,27 +418,27 @@ MASK TYPE PERFORMANCE COMPARISON
 ================================================================================
 Seq Len    Causal   Method     No Mask         Boolean Mask    Additive Mask
 --------------------------------------------------------------------------------
-32         False    jvp_attn   0.48 ms         0.49 ms (1.00x) 0.50 ms (1.02x)
-32         True     jvp_attn   0.48 ms         N/A             N/A
-64         False    jvp_attn   0.48 ms         0.47 ms (0.99x) 0.47 ms (0.99x)
-64         True     jvp_attn   0.47 ms         N/A             N/A
-128        False    jvp_attn   0.50 ms         0.51 ms (1.02x) 0.52 ms (1.05x)
-128        True     jvp_attn   0.47 ms         N/A             N/A
-256        False    jvp_attn   0.49 ms         0.52 ms (1.07x) 0.49 ms (1.01x)
-256        True     jvp_attn   0.49 ms         N/A             N/A
-512        False    jvp_attn   0.49 ms         0.49 ms (0.99x) 0.50 ms (1.03x)
-512        True     jvp_attn   0.50 ms         N/A             N/A
-1024       False    jvp_attn   0.50 ms         0.53 ms (1.05x) 0.53 ms (1.04x)
-1024       True     jvp_attn   0.52 ms         N/A             N/A
-2048       False    jvp_attn   0.76 ms         1.17 ms (1.54x) 0.89 ms (1.18x)
-2048       True     jvp_attn   0.55 ms         N/A             N/A
+32         False    jvp_attn   0.52 ms         0.50 ms (0.96x) 0.52 ms (1.00x)
+32         True     jvp_attn   0.53 ms         N/A             N/A
+64         False    jvp_attn   0.50 ms         0.50 ms (1.01x) 0.50 ms (1.01x)
+64         True     jvp_attn   0.51 ms         N/A             N/A
+128        False    jvp_attn   0.51 ms         0.48 ms (0.93x) 0.49 ms (0.96x)
+128        True     jvp_attn   0.54 ms         N/A             N/A
+256        False    jvp_attn   0.47 ms         0.51 ms (1.07x) 0.48 ms (1.01x)
+256        True     jvp_attn   0.50 ms         N/A             N/A
+512        False    jvp_attn   0.48 ms         0.49 ms (1.01x) 0.52 ms (1.07x)
+512        True     jvp_attn   0.48 ms         N/A             N/A
+1024       False    jvp_attn   0.49 ms         0.59 ms (1.22x) 0.71 ms (1.45x)
+1024       True     jvp_attn   0.53 ms         N/A             N/A
+2048       False    jvp_attn   1.34 ms         1.33 ms (0.99x) 1.27 ms (0.95x)
+2048       True     jvp_attn   0.75 ms         N/A             N/A
 
 ============================================================
 STATISTICS
 ============================================================
-Average speedup: 2.70x
-Min speedup: 0.90x
-Max speedup: 11.49x
+Average speedup: 2.83x
+Min speedup: 0.87x
+Max speedup: 11.09x
 
 Accuracy: 28/28 tests passed
 ✓ All accuracy checks passed!

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ from torch.nn.attention import SDPBackend, sdpa_kernel
 from jvp_flash_attention.jvp_attention import attention as jvp_attention
 
 with sdpa_kernel(SDPBackend.MATH):
-  # Regular attention
+  # Regular (quadratic) attention
   # x = F.scaled_dot_product_attention(
   #     q,
   #     k,
@@ -50,12 +50,13 @@ with sdpa_kernel(SDPBackend.MATH):
   #     dropout_p=attn_dropout_p if self.training else 0.0,
   # )
 
-  # Flash attention
+  # JVP flash attention
   x = jvp_attention(
       q,
       k,
       v,
-      # attn_mask=attn_mask,  # NOTE: Attention masking is not yet supported
+      attn_mask=attn_mask,
+      dropout_p=attn_dropout_p if self.training else 0.0,
   )
 ```
 
@@ -74,154 +75,373 @@ In principle, the kernel should support ROCm systems as well, though it has not 
 Results for `float16`:
 
 ```
-==========================================================================================
+==============================================================================================================
 BENCHMARK SUMMARY
-==========================================================================================
-Seq Len    Causal   Method     Time (ms)    Mem (MB)     TFLOP/s      Max Error    Grad Check
-------------------------------------------------------------------------------------------
-32         False    sdpa       0.551        0.64           0.0 TFLOP/s baseline     N/A
-32         False    jvp_attn   0.483        0.22           0.0 TFLOP/s 1.95e-03     ✓
+==============================================================================================================
+Seq Len    Causal   Mask       Method     Time (ms)    Mem (MB)     TFLOP/s      Max Error    Grad Check
+--------------------------------------------------------------------------------------------------------------
+32         False    additive   sdpa       0.788        0.64           0.0 TFLOP/s baseline     N/A
+32         False    additive   jvp_attn   0.496        0.23           0.0 TFLOP/s 1.95e-03     ✓
 
-32         True     sdpa       1.067        0.65           0.0 TFLOP/s baseline     N/A
-32         True     jvp_attn   0.465        0.22           0.0 TFLOP/s 1.95e-03     ✓
+32         False    boolean    sdpa       0.809        0.65           0.0 TFLOP/s baseline     N/A
+32         False    boolean    jvp_attn   0.488        0.22           0.0 TFLOP/s 1.95e-03     ✓
 
-64         False    sdpa       0.552        1.41           0.0 TFLOP/s baseline     N/A
-64         False    jvp_attn   0.469        0.43           0.0 TFLOP/s 9.77e-04     ✓
+32         False    none       sdpa       0.511        0.64           0.0 TFLOP/s baseline     N/A
+32         False    none       jvp_attn   0.493        0.22           0.0 TFLOP/s 1.95e-03     ✓
 
-64         True     sdpa       0.875        1.42           0.0 TFLOP/s baseline     N/A
-64         True     jvp_attn   0.469        0.43           0.0 TFLOP/s 1.95e-03     ✓
+32         True     none       sdpa       0.858        0.65           0.0 TFLOP/s baseline     N/A
+32         True     none       jvp_attn   0.501        0.22           0.0 TFLOP/s 1.95e-03     ✓
 
-128        False    sdpa       0.533        3.28           0.0 TFLOP/s baseline     N/A
-128        False    jvp_attn   0.467        0.86           0.1 TFLOP/s 9.77e-04     ✓
+64         False    additive   sdpa       0.809        1.41           0.0 TFLOP/s baseline     N/A
+64         False    additive   jvp_attn   0.502        0.47           0.0 TFLOP/s 9.77e-04     ✓
 
-128        True     sdpa       0.860        3.35           0.0 TFLOP/s baseline     N/A
-128        True     jvp_attn   0.494        0.86           0.0 TFLOP/s 1.95e-03     ✓
+64         False    boolean    sdpa       0.806        1.45           0.0 TFLOP/s baseline     N/A
+64         False    boolean    jvp_attn   0.488        0.43           0.0 TFLOP/s 9.77e-04     ✓
 
-256        False    sdpa       0.538        9.69           0.2 TFLOP/s baseline     N/A
-256        False    jvp_attn   0.473        1.72           0.4 TFLOP/s 9.77e-04     ✓
+64         False    none       sdpa       0.539        1.41           0.0 TFLOP/s baseline     N/A
+64         False    none       jvp_attn   0.494        0.43           0.0 TFLOP/s 9.77e-04     ✓
 
-256        True     sdpa       0.870        9.94           0.0 TFLOP/s baseline     N/A
-256        True     jvp_attn   0.468        1.72           0.2 TFLOP/s 1.95e-03     ✓
+64         True     none       sdpa       0.849        1.42           0.0 TFLOP/s baseline     N/A
+64         True     none       jvp_attn   0.479        0.43           0.0 TFLOP/s 1.95e-03     ✓
 
-512        False    sdpa       0.575        31.88          0.6 TFLOP/s baseline     N/A
-512        False    jvp_attn   0.466        3.45           1.5 TFLOP/s 4.88e-04     ✓
+128        False    additive   sdpa       0.803        3.28           0.0 TFLOP/s baseline     N/A
+128        False    additive   jvp_attn   0.488        1.02           0.1 TFLOP/s 9.77e-04     ✓
 
-512        True     sdpa       0.914        32.88          0.2 TFLOP/s baseline     N/A
-512        True     jvp_attn   0.467        3.45           0.7 TFLOP/s 1.95e-03     ✓
+128        False    boolean    sdpa       0.826        3.44           0.0 TFLOP/s baseline     N/A
+128        False    boolean    jvp_attn   0.472        0.86           0.1 TFLOP/s 9.77e-04     ✓
 
-1024       False    sdpa       1.291        113.77         1.1 TFLOP/s baseline     N/A
-1024       False    jvp_attn   0.463        6.89           5.9 TFLOP/s 4.88e-04     ✓
+128        False    none       sdpa       0.534        3.28           0.0 TFLOP/s baseline     N/A
+128        False    none       jvp_attn   0.519        0.86           0.1 TFLOP/s 9.77e-04     ✓
 
-1024       True     sdpa       1.467        117.77         0.5 TFLOP/s baseline     N/A
-1024       True     jvp_attn   0.470        6.89           2.9 TFLOP/s 1.95e-03     ✓
+128        True     none       sdpa       0.869        3.35           0.0 TFLOP/s baseline     N/A
+128        True     none       jvp_attn   0.497        0.86           0.0 TFLOP/s 1.95e-03     ✓
 
-2048       False    sdpa       3.669        427.54         1.5 TFLOP/s baseline     N/A
-2048       False    jvp_attn   0.462        13.79         23.7 TFLOP/s 2.44e-04     ✓
+256        False    additive   sdpa       0.861        9.69           0.1 TFLOP/s baseline     N/A
+256        False    additive   jvp_attn   0.511        2.35           0.3 TFLOP/s 9.77e-04     ✓
 
-2048       True     sdpa       4.287        443.54         0.6 TFLOP/s baseline     N/A
-2048       True     jvp_attn   0.463        13.79         11.8 TFLOP/s 1.95e-03     ✓
+256        False    boolean    sdpa       0.856        10.32          0.1 TFLOP/s baseline     N/A
+256        False    boolean    jvp_attn   0.494        1.72           0.3 TFLOP/s 9.77e-04     ✓
+
+256        False    none       sdpa       0.589        9.69           0.1 TFLOP/s baseline     N/A
+256        False    none       jvp_attn   0.476        1.72           0.4 TFLOP/s 9.77e-04     ✓
+
+256        True     none       sdpa       0.885        9.94           0.0 TFLOP/s baseline     N/A
+256        True     none       jvp_attn   0.480        1.72           0.2 TFLOP/s 1.95e-03     ✓
+
+512        False    additive   sdpa       1.003        31.88          0.3 TFLOP/s baseline     N/A
+512        False    additive   jvp_attn   0.508        5.95           1.3 TFLOP/s 4.88e-04     ✓
+
+512        False    boolean    sdpa       1.122        34.38          0.3 TFLOP/s baseline     N/A
+512        False    boolean    jvp_attn   0.515        3.45           1.3 TFLOP/s 4.88e-04     ✓
+
+512        False    none       sdpa       0.750        31.88          0.5 TFLOP/s baseline     N/A
+512        False    none       jvp_attn   0.496        3.45           1.4 TFLOP/s 4.88e-04     ✓
+
+512        True     none       sdpa       1.185        32.88          0.1 TFLOP/s baseline     N/A
+512        True     none       jvp_attn   0.496        3.45           0.7 TFLOP/s 1.95e-03     ✓
+
+1024       False    additive   sdpa       2.137        113.77         0.6 TFLOP/s baseline     N/A
+1024       False    additive   jvp_attn   0.503        16.89          5.4 TFLOP/s 4.88e-04     ✓
+
+1024       False    boolean    sdpa       2.166        123.77         0.6 TFLOP/s baseline     N/A
+1024       False    boolean    jvp_attn   0.516        6.89           5.3 TFLOP/s 4.88e-04     ✓
+
+1024       False    none       sdpa       1.934        113.77         0.7 TFLOP/s baseline     N/A
+1024       False    none       jvp_attn   0.520        6.89           5.3 TFLOP/s 4.88e-04     ✓
+
+1024       True     none       sdpa       2.169        117.77         0.3 TFLOP/s baseline     N/A
+1024       True     none       jvp_attn   0.493        6.89           2.8 TFLOP/s 1.95e-03     ✓
+
+2048       False    additive   sdpa       6.884        427.54         0.8 TFLOP/s baseline     N/A
+2048       False    additive   jvp_attn   0.702        53.79         15.6 TFLOP/s 2.44e-04     ✓
+
+2048       False    boolean    sdpa       6.992        467.54         0.8 TFLOP/s baseline     N/A
+2048       False    boolean    jvp_attn   0.566        13.79         19.3 TFLOP/s 2.44e-04     ✓
+
+2048       False    none       sdpa       5.820        427.54         0.9 TFLOP/s baseline     N/A
+2048       False    none       jvp_attn   0.507        13.79         21.6 TFLOP/s 2.44e-04     ✓
+
+2048       True     none       sdpa       6.906        443.54         0.4 TFLOP/s baseline     N/A
+2048       True     none       jvp_attn   0.522        13.79         10.5 TFLOP/s 1.95e-03     ✓
+
+
+================================================================================
+MASK TYPE PERFORMANCE COMPARISON
+================================================================================
+Seq Len    Causal   Method     No Mask         Boolean Mask    Additive Mask
+--------------------------------------------------------------------------------
+32         False    jvp_attn   0.49 ms         0.49 ms (0.99x) 0.50 ms (1.01x)
+32         True     jvp_attn   0.50 ms         N/A             N/A
+64         False    jvp_attn   0.49 ms         0.49 ms (0.99x) 0.50 ms (1.02x)
+64         True     jvp_attn   0.48 ms         N/A             N/A
+128        False    jvp_attn   0.52 ms         0.47 ms (0.91x) 0.49 ms (0.94x)
+128        True     jvp_attn   0.50 ms         N/A             N/A
+256        False    jvp_attn   0.48 ms         0.49 ms (1.04x) 0.51 ms (1.07x)
+256        True     jvp_attn   0.48 ms         N/A             N/A
+512        False    jvp_attn   0.50 ms         0.52 ms (1.04x) 0.51 ms (1.02x)
+512        True     jvp_attn   0.50 ms         N/A             N/A
+1024       False    jvp_attn   0.52 ms         0.52 ms (0.99x) 0.50 ms (0.97x)
+1024       True     jvp_attn   0.49 ms         N/A             N/A
+2048       False    jvp_attn   0.51 ms         0.57 ms (1.12x) 0.70 ms (1.39x)
+2048       True     jvp_attn   0.52 ms         N/A             N/A
+
+============================================================
+STATISTICS
+============================================================
+Average speedup: 3.44x
+Min speedup: 1.03x
+Max speedup: 13.23x
+
+Accuracy: 28/28 tests passed
+✓ All accuracy checks passed!
 ```
 
 Results for `bfloat16`:
 
 ```
-==========================================================================================
+==============================================================================================================
 BENCHMARK SUMMARY
-==========================================================================================
-Seq Len    Causal   Method     Time (ms)    Mem (MB)     TFLOP/s      Max Error    Grad Check
-------------------------------------------------------------------------------------------
-32         False    sdpa       0.527        0.64           0.0 TFLOP/s baseline     N/A
-32         False    jvp_attn   0.461        0.22           0.0 TFLOP/s 1.56e-02     ✓
+==============================================================================================================
+Seq Len    Causal   Mask       Method     Time (ms)    Mem (MB)     TFLOP/s      Max Error    Grad Check
+--------------------------------------------------------------------------------------------------------------
+32         False    additive   sdpa       0.764        0.64           0.0 TFLOP/s baseline     N/A
+32         False    additive   jvp_attn   0.497        0.23           0.0 TFLOP/s 1.56e-02     ✓
 
-32         True     sdpa       0.854        0.65           0.0 TFLOP/s baseline     N/A
-32         True     jvp_attn   0.462        0.22           0.0 TFLOP/s 1.56e-02     ✓
+32         False    boolean    sdpa       0.786        0.65           0.0 TFLOP/s baseline     N/A
+32         False    boolean    jvp_attn   0.468        0.22           0.0 TFLOP/s 1.56e-02     ✓
 
-64         False    sdpa       0.671        1.41           0.0 TFLOP/s baseline     N/A
-64         False    jvp_attn   0.459        0.43           0.0 TFLOP/s 7.81e-03     ✓
+32         False    none       sdpa       0.494        0.64           0.0 TFLOP/s baseline     N/A
+32         False    none       jvp_attn   0.470        0.22           0.0 TFLOP/s 1.56e-02     ✓
 
-64         True     sdpa       0.846        1.42           0.0 TFLOP/s baseline     N/A
-64         True     jvp_attn   0.459        0.43           0.0 TFLOP/s 1.56e-02     ✓
+32         True     none       sdpa       0.850        0.65           0.0 TFLOP/s baseline     N/A
+32         True     none       jvp_attn   0.469        0.22           0.0 TFLOP/s 1.56e-02     ✓
 
-128        False    sdpa       0.539        3.28           0.0 TFLOP/s baseline     N/A
-128        False    jvp_attn   0.463        0.86           0.1 TFLOP/s 7.81e-03     ✓
+64         False    additive   sdpa       0.814        1.41           0.0 TFLOP/s baseline     N/A
+64         False    additive   jvp_attn   0.488        0.47           0.0 TFLOP/s 7.81e-03     ✓
 
-128        True     sdpa       0.860        3.35           0.0 TFLOP/s baseline     N/A
-128        True     jvp_attn   0.484        0.86           0.0 TFLOP/s 1.56e-02     ✓
+64         False    boolean    sdpa       0.916        1.45           0.0 TFLOP/s baseline     N/A
+64         False    boolean    jvp_attn   0.540        0.43           0.0 TFLOP/s 7.81e-03     ✓
 
-256        False    sdpa       0.530        9.69           0.2 TFLOP/s baseline     N/A
-256        False    jvp_attn   0.468        1.72           0.4 TFLOP/s 3.91e-03     ✓
+64         False    none       sdpa       0.515        1.41           0.0 TFLOP/s baseline     N/A
+64         False    none       jvp_attn   0.471        0.43           0.0 TFLOP/s 7.81e-03     ✓
 
-256        True     sdpa       0.856        9.94           0.0 TFLOP/s baseline     N/A
-256        True     jvp_attn   0.468        1.72           0.2 TFLOP/s 1.56e-02     ✓
+64         True     none       sdpa       0.821        1.42           0.0 TFLOP/s baseline     N/A
+64         True     none       jvp_attn   0.471        0.43           0.0 TFLOP/s 1.56e-02     ✓
 
-512        False    sdpa       0.573        31.88          0.6 TFLOP/s baseline     N/A
-512        False    jvp_attn   0.469        3.45           1.5 TFLOP/s 3.91e-03     ✓
+128        False    additive   sdpa       0.767        3.28           0.0 TFLOP/s baseline     N/A
+128        False    additive   jvp_attn   0.487        1.02           0.1 TFLOP/s 7.81e-03     ✓
 
-512        True     sdpa       0.869        32.88          0.2 TFLOP/s baseline     N/A
-512        True     jvp_attn   0.468        3.45           0.7 TFLOP/s 1.56e-02     ✓
+128        False    boolean    sdpa       0.821        3.44           0.0 TFLOP/s baseline     N/A
+128        False    boolean    jvp_attn   0.482        0.86           0.1 TFLOP/s 7.81e-03     ✓
 
-1024       False    sdpa       1.290        113.77         1.1 TFLOP/s baseline     N/A
-1024       False    jvp_attn   0.462        6.89           5.9 TFLOP/s 3.91e-03     ✓
+128        False    none       sdpa       0.506        3.28           0.0 TFLOP/s baseline     N/A
+128        False    none       jvp_attn   0.486        0.86           0.1 TFLOP/s 7.81e-03     ✓
 
-1024       True     sdpa       1.466        117.77         0.5 TFLOP/s baseline     N/A
-1024       True     jvp_attn   0.461        6.89           3.0 TFLOP/s 1.56e-02     ✓
+128        True     none       sdpa       0.843        3.35           0.0 TFLOP/s baseline     N/A
+128        True     none       jvp_attn   0.473        0.86           0.0 TFLOP/s 1.56e-02     ✓
 
-2048       False    sdpa       3.673        427.54         1.5 TFLOP/s baseline     N/A
-2048       False    jvp_attn   0.462        13.79         23.7 TFLOP/s 1.95e-03     ✓
+256        False    additive   sdpa       0.822        9.69           0.1 TFLOP/s baseline     N/A
+256        False    additive   jvp_attn   0.495        2.35           0.3 TFLOP/s 7.81e-03     ✓
 
-2048       True     sdpa       4.286        443.54         0.6 TFLOP/s baseline     N/A
-2048       True     jvp_attn   0.452        13.79         12.1 TFLOP/s 3.12e-02     ✓
+256        False    boolean    sdpa       0.849        10.32          0.1 TFLOP/s baseline     N/A
+256        False    boolean    jvp_attn   0.470        1.72           0.4 TFLOP/s 7.81e-03     ✓
+
+256        False    none       sdpa       0.602        9.69           0.1 TFLOP/s baseline     N/A
+256        False    none       jvp_attn   0.465        1.72           0.4 TFLOP/s 3.91e-03     ✓
+
+256        True     none       sdpa       1.028        9.94           0.0 TFLOP/s baseline     N/A
+256        True     none       jvp_attn   0.462        1.72           0.2 TFLOP/s 1.56e-02     ✓
+
+512        False    additive   sdpa       1.104        31.88          0.3 TFLOP/s baseline     N/A
+512        False    additive   jvp_attn   0.617        5.95           1.1 TFLOP/s 3.91e-03     ✓
+
+512        False    boolean    sdpa       1.158        34.38          0.3 TFLOP/s baseline     N/A
+512        False    boolean    jvp_attn   0.502        3.45           1.4 TFLOP/s 3.91e-03     ✓
+
+512        False    none       sdpa       0.924        31.88          0.4 TFLOP/s baseline     N/A
+512        False    none       jvp_attn   0.478        3.45           1.4 TFLOP/s 3.91e-03     ✓
+
+512        True     none       sdpa       0.935        32.88          0.2 TFLOP/s baseline     N/A
+512        True     none       jvp_attn   0.462        3.45           0.7 TFLOP/s 1.56e-02     ✓
+
+1024       False    additive   sdpa       2.151        113.77         0.6 TFLOP/s baseline     N/A
+1024       False    additive   jvp_attn   0.497        16.89          5.5 TFLOP/s 3.91e-03     ✓
+
+1024       False    boolean    sdpa       2.224        123.77         0.6 TFLOP/s baseline     N/A
+1024       False    boolean    jvp_attn   0.487        6.89           5.6 TFLOP/s 3.91e-03     ✓
+
+1024       False    none       sdpa       1.936        113.77         0.7 TFLOP/s baseline     N/A
+1024       False    none       jvp_attn   0.487        6.89           5.6 TFLOP/s 3.91e-03     ✓
+
+1024       True     none       sdpa       2.149        117.77         0.3 TFLOP/s baseline     N/A
+1024       True     none       jvp_attn   0.484        6.89           2.8 TFLOP/s 1.56e-02     ✓
+
+2048       False    additive   sdpa       6.891        427.54         0.8 TFLOP/s baseline     N/A
+2048       False    additive   jvp_attn   0.550        53.79         19.9 TFLOP/s 1.95e-03     ✓
+
+2048       False    boolean    sdpa       7.020        467.54         0.8 TFLOP/s baseline     N/A
+2048       False    boolean    jvp_attn   0.550        13.79         19.9 TFLOP/s 1.95e-03     ✓
+
+2048       False    none       sdpa       5.827        427.54         0.9 TFLOP/s baseline     N/A
+2048       False    none       jvp_attn   0.532        13.79         20.6 TFLOP/s 1.95e-03     ✓
+
+2048       True     none       sdpa       6.914        443.54         0.4 TFLOP/s baseline     N/A
+2048       True     none       jvp_attn   0.549        13.79         10.0 TFLOP/s 3.12e-02     ✓
+
+
+================================================================================
+MASK TYPE PERFORMANCE COMPARISON
+================================================================================
+Seq Len    Causal   Method     No Mask         Boolean Mask    Additive Mask
+--------------------------------------------------------------------------------
+32         False    jvp_attn   0.47 ms         0.47 ms (1.00x) 0.50 ms (1.06x)
+32         True     jvp_attn   0.47 ms         N/A             N/A
+64         False    jvp_attn   0.47 ms         0.54 ms (1.15x) 0.49 ms (1.04x)
+64         True     jvp_attn   0.47 ms         N/A             N/A
+128        False    jvp_attn   0.49 ms         0.48 ms (0.99x) 0.49 ms (1.00x)
+128        True     jvp_attn   0.47 ms         N/A             N/A
+256        False    jvp_attn   0.47 ms         0.47 ms (1.01x) 0.49 ms (1.06x)
+256        True     jvp_attn   0.46 ms         N/A             N/A
+512        False    jvp_attn   0.48 ms         0.50 ms (1.05x) 0.62 ms (1.29x)
+512        True     jvp_attn   0.46 ms         N/A             N/A
+1024       False    jvp_attn   0.49 ms         0.49 ms (1.00x) 0.50 ms (1.02x)
+1024       True     jvp_attn   0.48 ms         N/A             N/A
+2048       False    jvp_attn   0.53 ms         0.55 ms (1.04x) 0.55 ms (1.03x)
+2048       True     jvp_attn   0.55 ms         N/A             N/A
+
+============================================================
+STATISTICS
+============================================================
+Average speedup: 3.56x
+Min speedup: 1.04x
+Max speedup: 12.76x
+
+Accuracy: 28/28 tests passed
+✓ All accuracy checks passed!
 ```
 
 Results for `float32`:
 
 ```
-==========================================================================================
+==============================================================================================================
 BENCHMARK SUMMARY
-==========================================================================================
-Seq Len    Causal   Method     Time (ms)    Mem (MB)     TFLOP/s      Max Error    Grad Check
-------------------------------------------------------------------------------------------
-32         False    sdpa       0.456        0.51           0.0 TFLOP/s baseline     N/A
-32         False    jvp_attn   0.454        0.43           0.0 TFLOP/s 7.22e-03     ✓
+==============================================================================================================
+Seq Len    Causal   Mask       Method     Time (ms)    Mem (MB)     TFLOP/s      Max Error    Grad Check
+--------------------------------------------------------------------------------------------------------------
+32         False    additive   sdpa       0.724        0.51           0.0 TFLOP/s baseline     N/A
+32         False    additive   jvp_attn   0.495        0.45           0.0 TFLOP/s 7.21e-03     ✓
 
-32         True     sdpa       0.779        0.51           0.0 TFLOP/s baseline     N/A
-32         True     jvp_attn   0.458        0.43           0.0 TFLOP/s 6.18e-03     ✓
+32         False    boolean    sdpa       0.718        0.53           0.0 TFLOP/s baseline     N/A
+32         False    boolean    jvp_attn   0.487        0.43           0.0 TFLOP/s 7.21e-03     ✓
 
-64         False    sdpa       0.460        1.09           0.0 TFLOP/s baseline     N/A
-64         False    jvp_attn   0.462        0.86           0.0 TFLOP/s 7.03e-03     ✓
+32         False    none       sdpa       0.438        0.51           0.0 TFLOP/s baseline     N/A
+32         False    none       jvp_attn   0.484        0.43           0.0 TFLOP/s 7.22e-03     ✓
 
-64         True     sdpa       0.787        1.11           0.0 TFLOP/s baseline     N/A
-64         True     jvp_attn   0.462        0.86           0.0 TFLOP/s 6.18e-03     ✓
+32         True     none       sdpa       0.750        0.51           0.0 TFLOP/s baseline     N/A
+32         True     none       jvp_attn   0.475        0.43           0.0 TFLOP/s 6.18e-03     ✓
 
-128        False    sdpa       0.460        2.81           0.0 TFLOP/s baseline     N/A
-128        False    jvp_attn   0.461        1.72           0.1 TFLOP/s 5.07e-03     ✓
+64         False    additive   sdpa       0.697        1.09           0.0 TFLOP/s baseline     N/A
+64         False    additive   jvp_attn   0.475        0.94           0.0 TFLOP/s 7.17e-03     ✓
 
-128        True     sdpa       0.782        2.88           0.0 TFLOP/s baseline     N/A
-128        True     jvp_attn   0.472        1.72           0.0 TFLOP/s 6.18e-03     ✓
+64         False    boolean    sdpa       0.710        1.17           0.0 TFLOP/s baseline     N/A
+64         False    boolean    jvp_attn   0.474        0.86           0.0 TFLOP/s 7.17e-03     ✓
 
-256        False    sdpa       0.457        8.75           0.2 TFLOP/s baseline     N/A
-256        False    jvp_attn   0.465        3.44           0.4 TFLOP/s 3.67e-03     ✓
+64         False    none       sdpa       0.432        1.09           0.0 TFLOP/s baseline     N/A
+64         False    none       jvp_attn   0.478        0.86           0.0 TFLOP/s 7.03e-03     ✓
 
-256        True     sdpa       0.798        9.00           0.1 TFLOP/s baseline     N/A
-256        True     jvp_attn   0.465        3.44           0.2 TFLOP/s 5.78e-03     ✓
+64         True     none       sdpa       0.783        1.11           0.0 TFLOP/s baseline     N/A
+64         True     none       jvp_attn   0.471        0.86           0.0 TFLOP/s 6.18e-03     ✓
 
-512        False    sdpa       0.530        30.01          0.6 TFLOP/s baseline     N/A
-512        False    jvp_attn   0.469        6.88           1.5 TFLOP/s 2.88e-03     ✓
+128        False    additive   sdpa       0.755        2.81           0.0 TFLOP/s baseline     N/A
+128        False    additive   jvp_attn   0.523        2.03           0.1 TFLOP/s 5.41e-03     ✓
 
-512        True     sdpa       0.784        31.01          0.2 TFLOP/s baseline     N/A
-512        True     jvp_attn   0.460        6.88           0.7 TFLOP/s 5.13e-03     ✓
+128        False    boolean    sdpa       0.767        3.13           0.0 TFLOP/s baseline     N/A
+128        False    boolean    jvp_attn   0.508        1.72           0.1 TFLOP/s 5.41e-03     ✓
 
-1024       False    sdpa       1.207        110.02         1.1 TFLOP/s baseline     N/A
-1024       False    jvp_attn   0.467        13.77          5.9 TFLOP/s 2.61e-03     ✓
+128        False    none       sdpa       0.467        2.81           0.0 TFLOP/s baseline     N/A
+128        False    none       jvp_attn   0.497        1.72           0.1 TFLOP/s 5.07e-03     ✓
 
-1024       True     sdpa       1.379        115.02         0.5 TFLOP/s baseline     N/A
-1024       True     jvp_attn   0.465        13.77          2.9 TFLOP/s 5.61e-03     ✓
+128        True     none       sdpa       0.743        2.88           0.0 TFLOP/s baseline     N/A
+128        True     none       jvp_attn   0.467        1.72           0.0 TFLOP/s 6.18e-03     ✓
 
-2048       False    sdpa       3.435        420.04         1.6 TFLOP/s baseline     N/A
-2048       False    jvp_attn   0.496        27.54         22.1 TFLOP/s 1.56e-03     ✓
+256        False    additive   sdpa       0.745        8.75           0.1 TFLOP/s baseline     N/A
+256        False    additive   jvp_attn   0.495        4.69           0.3 TFLOP/s 3.41e-03     ✓
 
-2048       True     sdpa       4.051        436.04         0.7 TFLOP/s baseline     N/A
-2048       True     jvp_attn   0.486        27.54         11.3 TFLOP/s 6.47e-03     ✓
+256        False    boolean    sdpa       0.790        10.00          0.1 TFLOP/s baseline     N/A
+256        False    boolean    jvp_attn   0.522        3.44           0.3 TFLOP/s 3.41e-03     ✓
+
+256        False    none       sdpa       0.502        8.75           0.2 TFLOP/s baseline     N/A
+256        False    none       jvp_attn   0.487        3.44           0.4 TFLOP/s 3.67e-03     ✓
+
+256        True     none       sdpa       0.780        9.00           0.1 TFLOP/s baseline     N/A
+256        True     none       jvp_attn   0.487        3.44           0.2 TFLOP/s 5.78e-03     ✓
+
+512        False    additive   sdpa       1.013        30.01          0.3 TFLOP/s baseline     N/A
+512        False    additive   jvp_attn   0.503        11.88          1.4 TFLOP/s 3.09e-03     ✓
+
+512        False    boolean    sdpa       0.833        35.01          0.4 TFLOP/s baseline     N/A
+512        False    boolean    jvp_attn   0.485        6.88           1.4 TFLOP/s 3.09e-03     ✓
+
+512        False    none       sdpa       0.698        30.01          0.5 TFLOP/s baseline     N/A
+512        False    none       jvp_attn   0.489        6.88           1.4 TFLOP/s 2.88e-03     ✓
+
+512        True     none       sdpa       1.073        31.01          0.2 TFLOP/s baseline     N/A
+512        True     none       jvp_attn   0.496        6.88           0.7 TFLOP/s 5.13e-03     ✓
+
+1024       False    additive   sdpa       2.139        110.02         0.6 TFLOP/s baseline     N/A
+1024       False    additive   jvp_attn   0.526        33.77          5.2 TFLOP/s 2.84e-03     ✓
+
+1024       False    boolean    sdpa       2.092        130.02         0.7 TFLOP/s baseline     N/A
+1024       False    boolean    jvp_attn   0.529        13.77          5.2 TFLOP/s 2.84e-03     ✓
+
+1024       False    none       sdpa       1.845        110.02         0.7 TFLOP/s baseline     N/A
+1024       False    none       jvp_attn   0.503        13.77          5.4 TFLOP/s 2.61e-03     ✓
+
+1024       True     none       sdpa       2.107        115.02         0.3 TFLOP/s baseline     N/A
+1024       True     none       jvp_attn   0.523        13.77          2.6 TFLOP/s 5.61e-03     ✓
+
+2048       False    additive   sdpa       6.535        420.04         0.8 TFLOP/s baseline     N/A
+2048       False    additive   jvp_attn   0.893        107.54        12.3 TFLOP/s 1.57e-03     ✓
+
+2048       False    boolean    sdpa       6.656        500.04         0.8 TFLOP/s baseline     N/A
+2048       False    boolean    jvp_attn   1.167        27.54          9.4 TFLOP/s 1.57e-03     ✓
+
+2048       False    none       sdpa       4.616        420.04         1.2 TFLOP/s baseline     N/A
+2048       False    none       jvp_attn   0.759        27.54         14.4 TFLOP/s 1.56e-03     ✓
+
+2048       True     none       sdpa       6.348        436.04         0.4 TFLOP/s baseline     N/A
+2048       True     none       jvp_attn   0.553        27.54          9.9 TFLOP/s 6.47e-03     ✓
+
+
+================================================================================
+MASK TYPE PERFORMANCE COMPARISON
+================================================================================
+Seq Len    Causal   Method     No Mask         Boolean Mask    Additive Mask
+--------------------------------------------------------------------------------
+32         False    jvp_attn   0.48 ms         0.49 ms (1.00x) 0.50 ms (1.02x)
+32         True     jvp_attn   0.48 ms         N/A             N/A
+64         False    jvp_attn   0.48 ms         0.47 ms (0.99x) 0.47 ms (0.99x)
+64         True     jvp_attn   0.47 ms         N/A             N/A
+128        False    jvp_attn   0.50 ms         0.51 ms (1.02x) 0.52 ms (1.05x)
+128        True     jvp_attn   0.47 ms         N/A             N/A
+256        False    jvp_attn   0.49 ms         0.52 ms (1.07x) 0.49 ms (1.01x)
+256        True     jvp_attn   0.49 ms         N/A             N/A
+512        False    jvp_attn   0.49 ms         0.49 ms (0.99x) 0.50 ms (1.03x)
+512        True     jvp_attn   0.50 ms         N/A             N/A
+1024       False    jvp_attn   0.50 ms         0.53 ms (1.05x) 0.53 ms (1.04x)
+1024       True     jvp_attn   0.52 ms         N/A             N/A
+2048       False    jvp_attn   0.76 ms         1.17 ms (1.54x) 0.89 ms (1.18x)
+2048       True     jvp_attn   0.55 ms         N/A             N/A
+
+============================================================
+STATISTICS
+============================================================
+Average speedup: 2.70x
+Min speedup: 0.90x
+Max speedup: 11.49x
+
+Accuracy: 28/28 tests passed
+✓ All accuracy checks passed!
 ```
 
 ## License
@@ -263,4 +483,4 @@ If you use the code associated with this package or otherwise find this work use
     - *[Ryu1845](https://github.com/Ryu1845)*
     - [tridao](https://github.com/tridao)
 
-We thank each and every contributor!
+Thank you to each and every contributor!

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ If you use the code associated with this package or otherwise find this work use
   month = sep,
   title = {{JVP Flash Attention}},
   url = {https://github.com/amorehead/jvp_flash_attention},
-  version = {0.0.1},
+  version = {0.0.2},
   year = {2025}
 }
 ```

--- a/jvp_flash_attention/jvp_attention.py
+++ b/jvp_flash_attention/jvp_attention.py
@@ -1210,6 +1210,13 @@ def _attn_bwd_dkdv(
     start_m,
     num_steps,  #
     MASK: tl.constexpr,
+    # Args for masking/dropout
+    mask_ptr,
+    MASK_TYPE: tl.constexpr,
+    dropout_p,
+    philox_seed,
+    philox_offset_base,
+    ENABLE_DROPOUT: tl.constexpr,
 ):
     """The main inner-loop logic for computing dK and dV.
 
@@ -1234,6 +1241,13 @@ def _attn_bwd_dkdv(
         start_m: Starting index for M dimension.
         num_steps: Number of steps to unroll.
         MASK: Masking tensor.
+        mask_ptr: Pointer to the mask tensor.
+        MASK_TYPE: Type of masking (0: no mask, 1: boolean mask,
+                     2: additive mask).
+        dropout_p: Dropout probability.
+        philox_seed: Seed for Philox RNG.
+        philox_offset_base: Base offset for Philox RNG.
+        ENABLE_DROPOUT: Flag to enable dropout.
 
     Returns:
         dk: Gradient of the key tensor.
@@ -1255,11 +1269,28 @@ def _attn_bwd_dkdv(
         offs_m = curr_m + tl.arange(0, BLOCK_M1)
         m = tl.load(M + offs_m)
         qkT = tl.dot(k, qT)
-        pT = tl.math.exp2(qkT - m[None, :])
-        # Autoregressive masking.
+        # Causal masking before exponentiation.
         if MASK:
-            mask = offs_m[None, :] >= offs_n[:, None]
-            pT = tl.where(mask, pT, 0.0)
+            causal_mask = offs_m[None, :] >= offs_n[:, None]
+            qkT = tl.where(causal_mask, qkT, -1e6)
+        # External masking before exponentiation.
+        if MASK_TYPE > 0:
+            mask_offs = offs_m[None, :] * N_CTX + offs_n[:, None]
+            if MASK_TYPE == 1:
+                mask = tl.load(mask_ptr + mask_offs)
+                qkT = tl.where(mask, qkT, -1e6)
+            elif MASK_TYPE == 2:
+                add_mask = tl.load(mask_ptr + mask_offs)
+                qkT += add_mask
+        # Exponentiation.
+        pT = tl.math.exp2(qkT - m[None, :])
+        # Dropout after exponentiation.
+        if ENABLE_DROPOUT:
+            philox_offset = philox_offset_base + curr_m * N_CTX + start_n
+            dropout_mask, dropout_scale = create_dropout_mask(
+                philox_seed, philox_offset, dropout_p, BLOCK_M1, BLOCK_N1, N_CTX
+            )
+            pT = pT * dropout_mask.to(pT.dtype) * dropout_scale
         do = tl.load(do_ptrs)
         # Compute dV.
         ppT = pT
@@ -1302,6 +1333,13 @@ def _attn_bwd_dq(
     start_n,
     num_steps,  #
     MASK: tl.constexpr,
+    # Args for masking/dropout
+    mask_ptr,
+    MASK_TYPE: tl.constexpr,
+    dropout_p,
+    philox_seed,
+    philox_offset_base,
+    ENABLE_DROPOUT: tl.constexpr,
 ):
     """The main inner-loop logic for computing dQ.
 
@@ -1324,6 +1362,13 @@ def _attn_bwd_dq(
         start_n: Starting index for N dimension.
         num_steps: Number of steps to unroll.
         MASK: Masking tensor.
+        mask_ptr: Pointer to the mask tensor.
+        MASK_TYPE: Type of masking (0: no mask, 1: boolean mask,
+                        2: additive mask).
+        dropout_p: Dropout probability.
+        philox_seed: Seed for Philox RNG.
+        philox_offset_base: Base offset for Philox RNG.
+        ENABLE_DROPOUT: Flag to enable dropout.
 
     Returns:
         dq: Gradient of the query tensor.
@@ -1344,12 +1389,29 @@ def _attn_bwd_dq(
         kT = tl.load(kT_ptrs)
         vT = tl.load(vT_ptrs)
         qk = tl.dot(q, kT)
-        p = tl.math.exp2(qk - m)
-        # Autoregressive masking.
+        # Causal masking before exponentiation.
         if MASK:
             offs_n = curr_n + tl.arange(0, BLOCK_N2)
-            mask = offs_m[:, None] >= offs_n[None, :]
-            p = tl.where(mask, p, 0.0)
+            causal_mask = offs_m[:, None] >= offs_n[None, :]
+            qk = tl.where(causal_mask, qk, -1e6)
+        # External masking before exponentiation.
+        if MASK_TYPE > 0:
+            mask_offs = offs_m[:, None] * N_CTX + offs_n[None, :]
+            if MASK_TYPE == 1:
+                mask = tl.load(mask_ptr + mask_offs)
+                qk = tl.where(mask, qk, -1e6)
+            elif MASK_TYPE == 2:
+                add_mask = tl.load(mask_ptr + mask_offs)
+                qk += add_mask
+        # Exponentiation.
+        p = tl.math.exp2(qk - m)
+        # Dropout after exponentiation.
+        if ENABLE_DROPOUT:
+            philox_offset = philox_offset_base + start_m * N_CTX + curr_n
+            dropout_mask, dropout_scale = create_dropout_mask(
+                philox_seed, philox_offset, dropout_p, BLOCK_M2, BLOCK_N2, N_CTX
+            )
+            p = p * dropout_mask.to(p.dtype) * dropout_scale
         # Compute dP and dS.
         dp = tl.dot(do, vT).to(tl.float32)
         ds = p * (dp - Di[:, None])
@@ -1389,6 +1451,13 @@ def _attn_bwd(
     BLOCK_N2: tl.constexpr,  #
     BLK_SLICE_FACTOR: tl.constexpr,  #
     HEAD_DIM: tl.constexpr,
+    # Args for masking/dropout
+    mask_ptr,
+    MASK_TYPE: tl.constexpr,
+    dropout_p,
+    philox_seed,
+    philox_offset_base,
+    ENABLE_DROPOUT: tl.constexpr,
 ):
     """The main backward pass for the attention mechanism.
 
@@ -1415,6 +1484,13 @@ def _attn_bwd(
         BLOCK_N2: Block size for N dimension.
         BLK_SLICE_FACTOR: Block slice factor.
         HEAD_DIM: Head dimension size.
+        mask_ptr: Pointer to the mask tensor.
+        MASK_TYPE: Type of masking (0: no mask, 1: boolean mask,
+                        2: additive mask).
+        dropout_p: Dropout probability.
+        philox_seed: Seed for Philox RNG.
+        philox_offset_base: Base offset for Philox RNG.
+        ENABLE_DROPOUT: Flag to enable dropout.
     """
     LN2: tl.constexpr = 0.6931471824645996  # = ln(2)
 
@@ -1473,6 +1549,12 @@ def _attn_bwd(
         start_m,
         num_steps,  #
         MASK=True,  #
+        mask_ptr=mask_ptr,
+        MASK_TYPE=MASK_TYPE,
+        dropout_p=dropout_p,
+        philox_seed=philox_seed,
+        philox_offset_base=philox_offset_base,
+        ENABLE_DROPOUT=ENABLE_DROPOUT,
     )
 
     start_m += num_steps * MASK_BLOCK_M1
@@ -1500,6 +1582,12 @@ def _attn_bwd(
         start_m,
         num_steps,  #
         MASK=False,  #
+        mask_ptr=mask_ptr,
+        MASK_TYPE=MASK_TYPE,
+        dropout_p=dropout_p,
+        philox_seed=philox_seed,
+        philox_offset_base=philox_offset_base,
+        ENABLE_DROPOUT=ENABLE_DROPOUT,
     )
 
     dv_ptrs = DV + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
@@ -1549,6 +1637,12 @@ def _attn_bwd(
         end_n - num_steps * MASK_BLOCK_N2,
         num_steps,  #
         MASK=True,  #
+        mask_ptr=mask_ptr,
+        MASK_TYPE=MASK_TYPE,
+        dropout_p=dropout_p,
+        philox_seed=philox_seed,
+        philox_offset_base=philox_offset_base,
+        ENABLE_DROPOUT=ENABLE_DROPOUT,
     )
     end_n -= num_steps * MASK_BLOCK_N2
     # Stage 2
@@ -1572,6 +1666,12 @@ def _attn_bwd(
         end_n - num_steps * BLOCK_N2,
         num_steps,  #
         MASK=False,  #
+        mask_ptr=mask_ptr,
+        MASK_TYPE=MASK_TYPE,
+        dropout_p=dropout_p,
+        philox_seed=philox_seed,
+        philox_offset_base=philox_offset_base,
+        ENABLE_DROPOUT=ENABLE_DROPOUT,
     )
     # Write back dQ.
     dq_ptrs = DQ + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
@@ -1596,6 +1696,12 @@ class JVPAttn(Function):
         HEAD_DIM_K: int
         causal: bool
         grid: JVPAttn.Grid
+        mask_tensor: Tensor
+        MASK_TYPE: int
+        dropout_p: float
+        philox_seed: int
+        philox_offset: int
+        ENABLE_DROPOUT: bool
 
     class FwdOutCtxContrib(NamedTuple):
         """Forward output context contributions for JVP Attention."""
@@ -1605,6 +1711,12 @@ class JVPAttn(Function):
         grid: JVPAttn.Grid
         HEAD_DIM_K: int
         sm_scale: float
+        mask_tensor: Tensor
+        MASK_TYPE: int
+        dropout_p: float
+        philox_seed: int
+        philox_offset: int
+        ENABLE_DROPOUT: bool
 
     class FwdOut(NamedTuple):
         """Forward output for JVP Attention."""
@@ -1911,7 +2023,22 @@ class JVPAttn(Function):
                 **extra_kern_args,
             )
 
-        return JVPAttn.FwdOut(o, JVPAttn.FwdOutCtxContrib(o_t, M, grid, HEAD_DIM_K, sm_scale))
+        return JVPAttn.FwdOut(
+            o,
+            JVPAttn.FwdOutCtxContrib(
+                o_t,
+                M,
+                grid,
+                HEAD_DIM_K,
+                sm_scale,
+                mask_tensor,
+                MASK_TYPE,
+                dropout_p,
+                philox_seed,
+                0,
+                ENABLE_DROPOUT,
+            ),
+        )
 
     @staticmethod
     def setup_context(ctx: JVPAttn.FnCtx, inputs, outputs: JVPAttn.FwdOut) -> Tensor:
@@ -1936,13 +2063,31 @@ class JVPAttn(Function):
             warp_specialize,
             USE_TMA,
         ) = inputs
-        o, (o_t, M, grid, HEAD_DIM_K, sm_scale) = outputs
+        o, (
+            o_t,
+            M,
+            grid,
+            HEAD_DIM_K,
+            sm_scale,
+            mask_tensor,
+            MASK_TYPE,
+            dropout_p,
+            philox_seed,
+            philox_offset,
+            ENABLE_DROPOUT,
+        ) = outputs
         ctx.grid = grid
         ctx.save_for_forward(o_t)
         ctx.save_for_backward(q, k, v, o, M)
         ctx.sm_scale = sm_scale
         ctx.HEAD_DIM_K = HEAD_DIM_K
         ctx.causal = causal
+        ctx.mask_tensor = mask_tensor
+        ctx.MASK_TYPE = MASK_TYPE
+        ctx.dropout_p = dropout_p
+        ctx.philox_seed = philox_seed
+        ctx.philox_offset = philox_offset
+        ctx.ENABLE_DROPOUT = ENABLE_DROPOUT
 
     @staticmethod
     def fwd(
@@ -2149,6 +2294,12 @@ class JVPAttn(Function):
             BLOCK_N2=BLOCK_N2,  #
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
             HEAD_DIM=ctx.HEAD_DIM_K,  #
+            mask_ptr=ctx.mask_tensor,
+            MASK_TYPE=ctx.MASK_TYPE,
+            dropout_p=ctx.dropout_p,
+            philox_seed=ctx.philox_seed,
+            philox_offset_base=ctx.philox_offset,  # Same as forward
+            ENABLE_DROPOUT=ctx.ENABLE_DROPOUT,
             num_warps=NUM_WARPS,  #
             num_stages=NUM_STAGES,  #
         )

--- a/jvp_flash_attention/jvp_attention.py
+++ b/jvp_flash_attention/jvp_attention.py
@@ -2023,6 +2023,8 @@ class JVPAttn(Function):
                 **extra_kern_args,
             )
 
+        # TODO: Decide whether `0` is the right philox_offset here
+        philox_offset = 0
         return JVPAttn.FwdOut(
             o,
             JVPAttn.FwdOutCtxContrib(
@@ -2035,7 +2037,7 @@ class JVPAttn(Function):
                 MASK_TYPE,
                 dropout_p,
                 philox_seed,
-                0,
+                philox_offset,
                 ENABLE_DROPOUT,
             ),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "jvp_flash_attention"
-version = "0.0.1"
+version = "0.0.2"
 description = "Flash Attention Triton kernel with support for second-order derivatives"
 authors = [
     { name = "Alex Morehead", email = "alex.morehead@gmail.edu" }
 ]
 readme = "README.md"
-requires-python = ">=3.10,<3.11"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = [
     'artificial intelligence',

--- a/tests/test_jvp_attention.py
+++ b/tests/test_jvp_attention.py
@@ -195,6 +195,7 @@ class BenchmarkResult(NamedTuple):
     time_ms: float
     memory_allocated_mb: float
     memory_reserved_mb: float
+    mask_type: str  # 'none', 'boolean', or 'additive'
     flops: int | None = None
     accuracy: AccuracyMetrics | None = None
 
@@ -212,6 +213,8 @@ class Args:
     dtype: str = "float16"
     seed: int = 42
     validate_gradients: bool = True
+    test_masks: bool = True
+    mask_prob: float = 0.1  # Probability of masking out an attention weight
 
     @staticmethod
     def get_parser() -> ArgumentParser:
@@ -234,6 +237,17 @@ class Args:
             action="store_true",
             help="Skip gradient validation",
         )
+        parser.add_argument(
+            "--no-test-masks",
+            action="store_true",
+            help="Skip testing with attention masks",
+        )
+        parser.add_argument(
+            "--mask-prob",
+            default=0.1,
+            type=float,
+            help="Probability of masking out attention weights",
+        )
         return parser
 
     @staticmethod
@@ -241,7 +255,9 @@ class Args:
         """Create Args from a namespace."""
         kwargs = vars(namespace)
         validate_gradients = not kwargs.pop("no_validate_gradients", False)
+        test_masks = not kwargs.pop("no_test_masks", False)
         kwargs["validate_gradients"] = validate_gradients
+        kwargs["test_masks"] = test_masks
         return Args(**kwargs)
 
 
@@ -276,6 +292,53 @@ def create_test_tensors(
     )
 
     return tensors
+
+
+def create_attention_mask(
+    args: Args,
+    seq_len: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    mask_type: str,
+) -> Tensor | None:
+    """Create an attention mask for testing.
+
+    Args:
+        args: The training arguments.
+        seq_len: The sequence length.
+        device: The device to create the mask on.
+        dtype: The data type of the mask.
+        mask_type: Type of mask ('none', 'boolean', or 'additive').
+
+    Returns:
+        The attention mask tensor or None if mask_type is 'none'.
+    """
+    if mask_type == "none":
+        return None
+
+    gen = torch.Generator(device=device).manual_seed(args.seed + 1000)  # Different seed for masks
+    heads = args.model_dim // args.head_dim
+
+    if mask_type == "boolean":
+        # Create a boolean mask where True means "attend" and False means "ignore"
+        # We'll create a random mask with some positions masked out
+        mask = (
+            torch.rand(args.bsz, heads, seq_len, seq_len, device=device, generator=gen)
+            > args.mask_prob
+        )
+        return mask
+
+    elif mask_type == "additive":
+        # Create an additive mask with values to be added to attention scores
+        # Use -inf for positions to ignore, 0 for positions to attend
+        rand_mask = torch.rand(args.bsz, heads, seq_len, seq_len, device=device, generator=gen)
+        mask = torch.where(rand_mask > args.mask_prob, 0.0, -1e6)
+        # Convert to the target dtype
+        mask = mask.to(dtype)
+        return mask
+
+    else:
+        raise ValueError(f"Unknown mask type: {mask_type}")
 
 
 def loss_fn(out: Tensor, target: Tensor) -> Tensor:
@@ -402,6 +465,7 @@ def validate_accuracy_and_gradients(
     v_t: Tensor,
     target: Tensor,
     is_causal: bool,
+    attn_mask: Tensor | None = None,
     tolerance: float = 5e-3,
     grad_tolerance: float = 5e-4,
     non_causal_tangent_tolerance: float = 8e-3,
@@ -417,6 +481,7 @@ def validate_accuracy_and_gradients(
         v_t: The value tangent tensor.
         target: The target tensor.
         is_causal: Whether the attention is causal.
+        attn_mask: Optional attention mask tensor.
         tolerance: The tolerance for primal errors.
         grad_tolerance: The tolerance for gradient errors.
         non_causal_tangent_tolerance: The tolerance for non-causal tangent errors.
@@ -430,7 +495,9 @@ def validate_accuracy_and_gradients(
             q_p.clone(), k_p.clone(), v_p.clone(), q_t.clone(), k_t.clone(), v_t.clone()
         )
 
-        sdpa_out = scaled_dot_product_attention(q0, k0, v0, is_causal=is_causal)
+        sdpa_out = scaled_dot_product_attention(
+            q0, k0, v0, attn_mask=attn_mask, is_causal=is_causal
+        )
         sdpa_out.retain_grad()
         sdpa_op, sdpa_ot = fwAD.unpack_dual(sdpa_out)
 
@@ -442,7 +509,7 @@ def validate_accuracy_and_gradients(
             q_p.clone(), k_p.clone(), v_p.clone(), q_t.clone(), k_t.clone(), v_t.clone()
         )
 
-        jvp_out = JVPAttn.fwd_dual(q1, k1, v1, causal=is_causal)
+        jvp_out = JVPAttn.fwd_dual(q1, k1, v1, attn_mask=attn_mask, causal=is_causal)
         jvp_out.retain_grad()
         jvp_op, jvp_ot = fwAD.unpack_dual(jvp_out)
 
@@ -462,7 +529,7 @@ def validate_accuracy_and_gradients(
         )
 
         jvp_func_op, jvp_func_ot = torch.func.jvp(
-            partial(JVPAttn.fwd_dual, causal=is_causal), qkv_p, qkv_t
+            partial(JVPAttn.fwd_dual, attn_mask=attn_mask, causal=is_causal), qkv_p, qkv_t
         )
         jvp_func_op.retain_grad()
 
@@ -493,13 +560,13 @@ def validate_accuracy_and_gradients(
     # Validate using torch.testing.assert_close
     try:
         torch.testing.assert_close(
-            jvp_op, sdpa_op, atol=tolerance if is_causal else 4e-3, rtol=1e-5
+            jvp_op, sdpa_op, atol=tolerance if is_causal else 8e-3, rtol=1e-5
         )
         torch.testing.assert_close(
             # TODO: Improve this (causal) accuracy for longer sequence lengths
             jvp_func_op,
             sdpa_op,
-            atol=8e-3 if is_causal else 4e-3,
+            atol=tolerance if is_causal else 8e-3,
             rtol=1e-5,
         )
 
@@ -561,10 +628,15 @@ def run_benchmark_suite(args: Args) -> list[BenchmarkResult]:
 
     # NOTE: Length-32 sequences pose specific numerical accuracy challenges, and for
     # them you may need to disable Triton kernel autotuning to avoid CUDA indexing errors.
-    grad_tolerance_map = {32: 7e-4}  # ...
+    grad_tolerance_map = {32: 7.2e-4}  # ...
     tangent_tolerance_map = {32: 1.6e-2}  # ...
 
     results = []
+
+    # Define mask types to test
+    mask_types = ["none"]
+    if args.test_masks:
+        mask_types.extend(["boolean", "additive"])
 
     for seq_len in args.seq_lengths:
         print(f"\n{'='*60}")
@@ -577,130 +649,147 @@ def run_benchmark_suite(args: Args) -> list[BenchmarkResult]:
         # Create test tensors
         q_p, q_t, k_p, k_t, v_p, v_t, target = create_test_tensors(args, seq_len, device, dtype)
 
-        for is_causal in [False, True]:
-            print(f"\nCausal: {is_causal}")
-            print("-" * 40)
+        for mask_type in mask_types:
+            # Create attention mask if needed
+            attn_mask = create_attention_mask(args, seq_len, device, dtype, mask_type)
 
-            # Validate accuracy and gradients first
-            if args.validate_gradients:
-                print("Validating accuracy and gradients...")
-                accuracy_metrics = validate_accuracy_and_gradients(
-                    q_p,
-                    k_p,
-                    v_p,
-                    q_t,
-                    k_t,
-                    v_t,
-                    target,
-                    is_causal,
-                    tolerance=tolerance,
-                    grad_tolerance=grad_tolerance,
-                    non_causal_tangent_tolerance=non_causal_tangent_tolerance,
-                )
-                accuracy_metrics.tolerance = tolerance
+            for is_causal in [False, True]:
+                print(f"\nCausal: {is_causal}, Mask: {mask_type}")
+                print("-" * 40)
 
-                print(f"  Primal error: {accuracy_metrics.primal_error:.2e}")
-                print(f"  Tangent error: {accuracy_metrics.tangent_error:.2e}")
-                print(f"  Loss error: {accuracy_metrics.loss_error:.2e}")
-                print(f"  Q gradient error: {accuracy_metrics.q_grad_error:.2e}")
-                print(f"  K gradient error: {accuracy_metrics.k_grad_error:.2e}")
-                print(f"  V gradient error: {accuracy_metrics.v_grad_error:.2e}")
+                if is_causal and mask_type != "none":
+                    print("  Skipping invalid combination of causal + mask")
+                    continue
 
-                if accuracy_metrics.is_accurate():
-                    print("  ✓ All accuracy checks passed!")
+                # Validate accuracy and gradients first
+                if args.validate_gradients:
+                    print("Validating accuracy and gradients...")
+                    accuracy_metrics = validate_accuracy_and_gradients(
+                        q_p,
+                        k_p,
+                        v_p,
+                        q_t,
+                        k_t,
+                        v_t,
+                        target,
+                        is_causal,
+                        attn_mask=attn_mask,
+                        tolerance=tolerance,
+                        grad_tolerance=grad_tolerance,
+                        non_causal_tangent_tolerance=non_causal_tangent_tolerance,
+                    )
+                    accuracy_metrics.tolerance = tolerance
+
+                    print(f"  Primal error: {accuracy_metrics.primal_error:.2e}")
+                    print(f"  Tangent error: {accuracy_metrics.tangent_error:.2e}")
+                    print(f"  Loss error: {accuracy_metrics.loss_error:.2e}")
+                    print(f"  Q gradient error: {accuracy_metrics.q_grad_error:.2e}")
+                    print(f"  K gradient error: {accuracy_metrics.k_grad_error:.2e}")
+                    print(f"  V gradient error: {accuracy_metrics.v_grad_error:.2e}")
+
+                    if accuracy_metrics.is_accurate():
+                        print("  ✓ All accuracy checks passed!")
+                    else:
+                        print(f"  ⚠️  Max error {accuracy_metrics.max_error:.2e} exceeds tolerance")
                 else:
-                    print(f"  ⚠️  Max error {accuracy_metrics.max_error:.2e} exceeds tolerance")
-            else:
-                accuracy_metrics = None
+                    accuracy_metrics = None
 
-            # Benchmark performance
-            with sdpa_kernel(SDPBackend.MATH), fwAD.dual_level(), enable_grad():
-                # Create functions for benchmarking
-                def run_sdpa():
-                    """Run SDPA attention."""
-                    q, k, v = make_qkv(
-                        q_p.clone(),
-                        k_p.clone(),
-                        v_p.clone(),
-                        q_t.clone(),
-                        k_t.clone(),
-                        v_t.clone(),
+                # Benchmark performance
+                with sdpa_kernel(SDPBackend.MATH), fwAD.dual_level(), enable_grad():
+                    # Create functions for benchmarking
+                    def run_sdpa():
+                        """Run SDPA attention."""
+                        q, k, v = make_qkv(
+                            q_p.clone(),
+                            k_p.clone(),
+                            v_p.clone(),
+                            q_t.clone(),
+                            k_t.clone(),
+                            v_t.clone(),
+                        )
+                        out = scaled_dot_product_attention(
+                            q, k, v, attn_mask=attn_mask, is_causal=is_causal
+                        )
+
+                    def run_jvp_attn():
+                        """Run JVP attention."""
+                        q, k, v = make_qkv(
+                            q_p.clone(),
+                            k_p.clone(),
+                            v_p.clone(),
+                            q_t.clone(),
+                            k_t.clone(),
+                            v_t.clone(),
+                        )
+                        out = JVPAttn.fwd_dual(q, k, v, attn_mask=attn_mask, causal=is_causal)
+
+                    print("\nBenchmarking performance...")
+                    heads = args.model_dim // args.head_dim
+
+                    # Measure SDPA performance
+                    sdpa_time = benchmark_function(
+                        run_sdpa, args.warmup_iters, args.benchmark_iters
                     )
-                    out = scaled_dot_product_attention(q, k, v, is_causal=is_causal)
-
-                def run_jvp_attn():
-                    """Run JVP attention."""
-                    q, k, v = make_qkv(
-                        q_p.clone(),
-                        k_p.clone(),
-                        v_p.clone(),
-                        q_t.clone(),
-                        k_t.clone(),
-                        v_t.clone(),
+                    sdpa_mem_alloc, sdpa_mem_reserved = measure_memory_usage(run_sdpa)
+                    sdpa_flops = get_attention_flop_count(
+                        args.bsz, heads, seq_len, args.head_dim, is_causal, is_jvp=False
                     )
-                    out = JVPAttn.fwd_dual(q, k, v, causal=is_causal)
 
-                print("\nBenchmarking performance...")
-                heads = args.model_dim // args.head_dim
-
-                # Measure SDPA performance
-                sdpa_time = benchmark_function(run_sdpa, args.warmup_iters, args.benchmark_iters)
-                sdpa_mem_alloc, sdpa_mem_reserved = measure_memory_usage(run_sdpa)
-                sdpa_flops = get_attention_flop_count(
-                    args.bsz, heads, seq_len, args.head_dim, is_causal, is_jvp=False
-                )
-
-                # Measure JVP Attention performance
-                jvp_time = benchmark_function(
-                    run_jvp_attn, args.warmup_iters, args.benchmark_iters
-                )
-                jvp_mem_alloc, jvp_mem_reserved = measure_memory_usage(run_jvp_attn)
-                jvp_flops = get_attention_flop_count(
-                    args.bsz, heads, seq_len, args.head_dim, is_causal, is_jvp=True
-                )
-
-                # Store results
-                results.append(
-                    BenchmarkResult(
-                        seq_len=seq_len,
-                        is_causal=is_causal,
-                        method="sdpa",
-                        time_ms=sdpa_time,
-                        memory_allocated_mb=sdpa_mem_alloc,
-                        memory_reserved_mb=sdpa_mem_reserved,
-                        flops=sdpa_flops,
-                        accuracy=None,
+                    # Measure JVP Attention performance
+                    jvp_time = benchmark_function(
+                        run_jvp_attn, args.warmup_iters, args.benchmark_iters
                     )
-                )
-
-                results.append(
-                    BenchmarkResult(
-                        seq_len=seq_len,
-                        is_causal=is_causal,
-                        method="jvp_attn",
-                        time_ms=jvp_time,
-                        memory_allocated_mb=jvp_mem_alloc,
-                        memory_reserved_mb=jvp_mem_reserved,
-                        flops=jvp_flops,
-                        accuracy=accuracy_metrics,
+                    jvp_mem_alloc, jvp_mem_reserved = measure_memory_usage(run_jvp_attn)
+                    jvp_flops = get_attention_flop_count(
+                        args.bsz, heads, seq_len, args.head_dim, is_causal, is_jvp=True
                     )
-                )
 
-                # Print results
-                print("PyTorch SDPA:")
-                print(f"  Time: {sdpa_time:.3f} ms")
-                print(
-                    f"  Memory (alloc/reserved): {sdpa_mem_alloc:.2f}/{sdpa_mem_reserved:.2f} MB"
-                )
-                print(f"  FLOPS: {fmt_flops(mpi_to_flops(sdpa_time, sdpa_flops))}")
+                    # Store results
+                    results.append(
+                        BenchmarkResult(
+                            seq_len=seq_len,
+                            is_causal=is_causal,
+                            method="sdpa",
+                            time_ms=sdpa_time,
+                            memory_allocated_mb=sdpa_mem_alloc,
+                            memory_reserved_mb=sdpa_mem_reserved,
+                            mask_type=mask_type,
+                            flops=sdpa_flops,
+                            accuracy=None,
+                        )
+                    )
 
-                print("\nJVP Attention:")
-                print(f"  Time: {jvp_time:.3f} ms")
-                print(f"  Memory (alloc/reserved): {jvp_mem_alloc:.2f}/{jvp_mem_reserved:.2f} MB")
-                print(f"  FLOPS: {fmt_flops(mpi_to_flops(jvp_time, jvp_flops))}")
+                    results.append(
+                        BenchmarkResult(
+                            seq_len=seq_len,
+                            is_causal=is_causal,
+                            method="jvp_attn",
+                            time_ms=jvp_time,
+                            memory_allocated_mb=jvp_mem_alloc,
+                            memory_reserved_mb=jvp_mem_reserved,
+                            mask_type=mask_type,
+                            flops=jvp_flops,
+                            accuracy=accuracy_metrics,
+                        )
+                    )
 
-                print(f"\nSpeedup: {sdpa_time/jvp_time:.2f}x")
-                print(f"Memory ratio: {jvp_mem_alloc/sdpa_mem_alloc:.2f}x")
+                    # Print results
+                    print("PyTorch SDPA:")
+                    print(f"  Time: {sdpa_time:.3f} ms")
+                    print(
+                        f"  Memory (alloc/reserved): {sdpa_mem_alloc:.2f}/{sdpa_mem_reserved:.2f} MB"
+                    )
+                    print(f"  FLOPS: {fmt_flops(mpi_to_flops(sdpa_time, sdpa_flops))}")
+
+                    print("\nJVP Attention:")
+                    print(f"  Time: {jvp_time:.3f} ms")
+                    print(
+                        f"  Memory (alloc/reserved): {jvp_mem_alloc:.2f}/{jvp_mem_reserved:.2f} MB"
+                    )
+                    print(f"  FLOPS: {fmt_flops(mpi_to_flops(jvp_time, jvp_flops))}")
+
+                    print(f"\nSpeedup: {sdpa_time/jvp_time:.2f}x")
+                    print(f"Memory ratio: {jvp_mem_alloc/sdpa_mem_alloc:.2f}x")
 
     return results
 
@@ -711,28 +800,28 @@ def print_summary_table(results: list[BenchmarkResult]) -> None:
     Args:
         results: The list of benchmark results to summarize.
     """
-    print("\n" + "=" * 90)
+    print("\n" + "=" * 110)
     print("BENCHMARK SUMMARY")
-    print("=" * 90)
+    print("=" * 110)
 
-    # Group results by seq_len and causal
+    # Group results by seq_len, causal, and mask_type
     from collections import defaultdict
 
     grouped = defaultdict(dict)
 
     for r in results:
-        key = (r.seq_len, r.is_causal)
+        key = (r.seq_len, r.is_causal, r.mask_type)
         grouped[key][r.method] = r
 
     # Print header
     print(
-        f"{'Seq Len':<10} {'Causal':<8} {'Method':<10} "
+        f"{'Seq Len':<10} {'Causal':<8} {'Mask':<10} {'Method':<10} "
         f"{'Time (ms)':<12} {'Mem (MB)':<12} {'TFLOP/s':<12} "
         f"{'Max Error':<12} {'Grad Check':<10}"
     )
-    print("-" * 90)
+    print("-" * 110)
 
-    for (seq_len, is_causal), methods in sorted(grouped.items()):
+    for (seq_len, is_causal, mask_type), methods in sorted(grouped.items()):
         for method in ["sdpa", "jvp_attn"]:
             if method in methods:
                 r = methods[method]
@@ -746,32 +835,133 @@ def print_summary_table(results: list[BenchmarkResult]) -> None:
                     grad_check = "N/A"
 
                 print(
-                    f"{seq_len:<10} {str(is_causal):<8} {method:<10} "
+                    f"{seq_len:<10} {str(is_causal):<8} {mask_type:<10} {method:<10} "
                     f"{r.time_ms:<12.3f} {r.memory_allocated_mb:<12.2f} "
                     f"{flops_str:<12} {error_str:<12} {grad_check:<10}"
                 )
         print()
 
 
+def print_mask_comparison_table(results: list[BenchmarkResult]) -> None:
+    """Print a comparison table showing the impact of different mask types.
+
+    Args:
+        results: The list of benchmark results to analyze.
+    """
+    print("\n" + "=" * 80)
+    print("MASK TYPE PERFORMANCE COMPARISON")
+    print("=" * 80)
+
+    # Group by seq_len, is_causal, and method
+    from collections import defaultdict
+
+    grouped = defaultdict(lambda: defaultdict(dict))
+
+    for r in results:
+        grouped[(r.seq_len, r.is_causal, r.method)][r.mask_type] = r
+
+    print(
+        f"{'Seq Len':<10} {'Causal':<8} {'Method':<10} "
+        f"{'No Mask':<15} {'Boolean Mask':<15} {'Additive Mask':<15}"
+    )
+    print("-" * 80)
+
+    for (seq_len, is_causal, method), mask_results in sorted(grouped.items()):
+        if method == "jvp_attn":  # Only show JVP results for clarity
+            none_time = mask_results.get("none", None)
+            bool_time = mask_results.get("boolean", None)
+            add_time = mask_results.get("additive", None)
+
+            none_str = f"{none_time.time_ms:.2f} ms" if none_time else "N/A"
+            bool_str = f"{bool_time.time_ms:.2f} ms" if bool_time else "N/A"
+            add_str = f"{add_time.time_ms:.2f} ms" if add_time else "N/A"
+
+            # Add relative performance
+            if none_time and bool_time:
+                bool_str += f" ({bool_time.time_ms/none_time.time_ms:.2f}x)"
+            if none_time and add_time:
+                add_str += f" ({add_time.time_ms/none_time.time_ms:.2f}x)"
+
+            print(
+                f"{seq_len:<10} {str(is_causal):<8} {method:<10} "
+                f"{none_str:<15} {bool_str:<15} {add_str:<15}"
+            )
+
+
 def main(args: Args) -> None:
     """Main benchmarking loop."""
-    print("Flash Attention JVP Kernel Benchmark")
+    print("Flash Attention JVP Kernel Benchmark with Mask Testing")
     print(
         f"Configuration: bsz={args.bsz}, model_dim={args.model_dim}, "
         f"head_dim={args.head_dim}, dtype={args.dtype}"
     )
     print(f"Gradient validation: {'Enabled' if args.validate_gradients else 'Disabled'}")
+    print(f"Mask testing: {'Enabled' if args.test_masks else 'Disabled'}")
+    if args.test_masks:
+        print(f"Mask probability: {args.mask_prob}")
 
     # Seed everything
     random.seed(args.seed)
     if NUMPY_AVAILABLE:
         np.random.seed(args.seed)
     torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
 
     results = run_benchmark_suite(args)
+
+    # Print summary tables
     print_summary_table(results)
 
-    # Optional: Save results to file
+    # If masks were tested, print comparison table
+    if args.test_masks:
+        print_mask_comparison_table(results)
+
+    # Print statistics
+    print("\n" + "=" * 60)
+    print("STATISTICS")
+    print("=" * 60)
+
+    # Calculate average speedup
+    speedups = []
+    for i in range(0, len(results), 2):  # Assuming pairs of sdpa/jvp_attn
+        if i + 1 < len(results):
+            sdpa_result = results[i]
+            jvp_result = results[i + 1]
+            if sdpa_result.method == "sdpa" and jvp_result.method == "jvp_attn":
+                speedup = sdpa_result.time_ms / jvp_result.time_ms
+                speedups.append(speedup)
+
+    if speedups:
+        avg_speedup = sum(speedups) / len(speedups)
+        min_speedup = min(speedups)
+        max_speedup = max(speedups)
+        print(f"Average speedup: {avg_speedup:.2f}x")
+        print(f"Min speedup: {min_speedup:.2f}x")
+        print(f"Max speedup: {max_speedup:.2f}x")
+
+    # Calculate accuracy statistics
+    accuracy_results = [r for r in results if r.accuracy is not None]
+    if accuracy_results:
+        all_accurate = all(r.accuracy.is_accurate() for r in accuracy_results)
+        num_accurate = sum(1 for r in accuracy_results if r.accuracy.is_accurate())
+        print(f"\nAccuracy: {num_accurate}/{len(accuracy_results)} tests passed")
+        if all_accurate:
+            print("✓ All accuracy checks passed!")
+        else:
+            print("⚠️  Some accuracy checks failed")
+
+            # Show which configurations failed
+            failed_configs = [
+                (r.seq_len, r.is_causal, r.mask_type)
+                for r in accuracy_results
+                if not r.accuracy.is_accurate()
+            ]
+            if failed_configs:
+                print("\nFailed configurations:")
+                for seq_len, is_causal, mask_type in failed_configs:
+                    print(f"  - Seq={seq_len}, Causal={is_causal}, Mask={mask_type}")
+
+    # Save results to file
     import json
 
     # Convert results to JSON-serializable format
@@ -791,10 +981,39 @@ def main(args: Args) -> None:
             }
         results_data.append(result_dict)
 
-    output_filepath = os.path.join("tests", f"{args.dtype}_test_jvp_attention_results.json")
+    # Include configuration in filename
+    mask_suffix = "_with_masks" if args.test_masks else ""
+    output_filepath = os.path.join(
+        "tests", f"{args.dtype}_test_jvp_attention_results{mask_suffix}.json"
+    )
     os.makedirs(os.path.dirname(output_filepath), exist_ok=True)
+
+    # Save both results and configuration
+    output_data = {
+        "configuration": {
+            "bsz": args.bsz,
+            "model_dim": args.model_dim,
+            "head_dim": args.head_dim,
+            "seq_lengths": args.seq_lengths,
+            "dtype": args.dtype,
+            "seed": args.seed,
+            "test_masks": args.test_masks,
+            "mask_prob": args.mask_prob if args.test_masks else None,
+        },
+        "results": results_data,
+        "summary": {
+            "avg_speedup": avg_speedup if speedups else None,
+            "min_speedup": min_speedup if speedups else None,
+            "max_speedup": max_speedup if speedups else None,
+            "accuracy_rate": (
+                f"{num_accurate}/{len(accuracy_results)}" if accuracy_results else "N/A"
+            ),
+        },
+    }
+
     with open(output_filepath, "w") as f:
-        json.dump(results_data, f, indent=2, default=str)
+        json.dump(output_data, f, indent=2, default=str)
+
     print(f"\nResults saved to {output_filepath}")
 
 


### PR DESCRIPTION
- Adds support for attention masking and dropout, including with boolean and floating-point (B, H, N, N)-shaped `attn_mask` argument values. Where possible, I recommend using boolean `attn_mask`s, since they have minimal memory overhead compared to floating-point `attn_mask`s.
- Simplifies Python version requirement to `>=3.10` (@ArchiMickey).
- Bumps version to `0.0.2`.

* **NOTE:** Dropout has not been unit-tested. I would gladly welcome a PR to include dropout correctness verification within the unit testing suite! Since (I believe) attention dropout is less common/sought after these days, as well as TMA support for NVIDIA H100s, I have deprioritized these features in this PR.