### PR TITLE
Fix runtime bugs in TMA support, and support TMA masks

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ date-released: 2025-09-05
 authors:
   - family-names: "Morehead"
     given-names: "Alex"
-version: 0.0.6
+version: 0.0.7
 doi: 10.5281/zenodo.17050188
 license: "MIT"
 url: "https://zenodo.org/records/17050188"

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ If you use the code associated with this package or otherwise find this work use
   month = sep,
   title = {{JVP Flash Attention}},
   url = {https://github.com/amorehead/jvp_flash_attention},
-  version = {0.0.6},
+  version = {0.0.7},
   year = {2025}
 }
 ```

--- a/jvp_flash_attention/jvp_attention.py
+++ b/jvp_flash_attention/jvp_attention.py
@@ -2380,7 +2380,7 @@ class JVPAttn(Function):
                 v_strides = [HEAD_DIM_K, 1]
             desc_v = TensorDescriptor(v, shape=v_shape, strides=v_strides, block_shape=dummy_block)
             # NOTE: Probably we could share the shape and strides from above, but whatever
-            if q_t.dtype == torch.float8_e5m2:
+            if q_t is not None and q_t.dtype == torch.float8_e5m2:
                 t_v_shape = [HEAD_DIM_K, y_dim]
                 t_v_strides = [q_t.shape[2], 1]
             else:

--- a/jvp_flash_attention/jvp_attention.py
+++ b/jvp_flash_attention/jvp_attention.py
@@ -2355,7 +2355,7 @@ class JVPAttn(Function):
             # NOTE: On Hopper, we cannot perform a FP8 dot with a non-transposed second tensor.
             y_dim = Z_H * N_CTX
 
-            dummy_block = [1, 1]
+            dummy_block = [MIN_SEQUENCE_LENGTH, MIN_SEQUENCE_LENGTH]
             desc_q = TensorDescriptor(
                 q,
                 shape=[y_dim, HEAD_DIM_K],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jvp_flash_attention"
-version = "0.0.6"
+version = "0.0.7"
 description = "Flash Attention Triton kernel with support for second-order derivatives"
 authors = [
     { name = "Alex Morehead", email = "alex.morehead@gmail.edu" }


### PR DESCRIPTION
Bumps version to `0.0.7`:
* Fixes runtime bugs when running on Tensor Memory Accelerator (TMA) GPUs (e.g., NVIDIA H100s).
* Adds masking support for TMA GPUs.
* **Note:** TMA masking could be further improved by storing the `attn_mask` tensor in TMA memory (at a later date). For now, the `attn_mask` tensor is managed with a block pointer.